### PR TITLE
Per-service credentials, PAYG allocation split, admin overhaul

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -12,6 +12,215 @@ require_once __DIR__ . '/lib/VDCManager.php';
 require_once __DIR__ . '/lib/CustomFieldFunctions.php';
 
 /**
+ * Auto-migrate legacy data for a single MultiPortal service.
+ *
+ * Moves client-level credentials and old relid=0 Last Usage Sync into
+ * per-product custom fields. Safe to call repeatedly — never overwrites
+ * existing values. Returns true if any migration was performed.
+ */
+function multiportal_autoMigrateService($serviceId)
+{
+    $hosting = Capsule::table('tblhosting')->where('id', $serviceId)->first();
+    if (!$hosting) {
+        return false;
+    }
+    $productId = $hosting->packageid;
+    $clientId = $hosting->userid;
+    $migrated = false;
+
+    // Ensure per-product custom fields exist before trying to migrate into them
+    $requiredFields = [
+        ['fieldname' => 'Tenant UUID', 'description' => 'MultiPortal tenant identifier for this service', 'sortorder' => 1],
+        ['fieldname' => 'URL', 'description' => 'MultiPortal portal URL for this service', 'sortorder' => 2],
+        ['fieldname' => 'Last Usage Sync', 'description' => 'Last PAYG usage sync date', 'sortorder' => 3],
+    ];
+    foreach ($requiredFields as $field) {
+        $existing = Capsule::table('tblcustomfields')
+            ->where('type', 'product')->where('fieldname', $field['fieldname'])
+            ->where('relid', $productId)->first();
+        if (!$existing) {
+            Capsule::table('tblcustomfields')->insert([
+                'type' => 'product', 'relid' => $productId,
+                'fieldname' => $field['fieldname'], 'fieldtype' => 'text',
+                'description' => $field['description'], 'fieldoptions' => '',
+                'regexpr' => '', 'adminonly' => 'on', 'required' => '',
+                'showorder' => '', 'showinvoice' => '', 'sortorder' => $field['sortorder'],
+            ]);
+        }
+    }
+
+    // Helper: get a client-level custom field value
+    $getClientField = function ($fieldName) use ($clientId) {
+        $field = Capsule::table('tblcustomfields')
+            ->where('type', 'client')->where('fieldname', $fieldName)->first();
+        if (!$field) return null;
+        return Capsule::table('tblcustomfieldsvalues')
+            ->where('fieldid', $field->id)->where('relid', $clientId)->value('value');
+    };
+
+    // Helper: get a product-level custom field value (per-product first, then relid=0)
+    $getProductField = function ($fieldName) use ($serviceId, $productId) {
+        $field = Capsule::table('tblcustomfields')
+            ->where('type', 'product')->where('fieldname', $fieldName)
+            ->where('relid', $productId)->first();
+        if (!$field) {
+            $field = Capsule::table('tblcustomfields')
+                ->where('type', 'product')->where('fieldname', $fieldName)
+                ->where('relid', 0)->first();
+        }
+        if (!$field) return null;
+        return Capsule::table('tblcustomfieldsvalues')
+            ->where('fieldid', $field->id)->where('relid', $serviceId)->value('value');
+    };
+
+    // Helper: set a product-level custom field value (per-product field only)
+    $setProductField = function ($fieldName, $value) use ($serviceId, $productId) {
+        $field = Capsule::table('tblcustomfields')
+            ->where('type', 'product')->where('fieldname', $fieldName)
+            ->where('relid', $productId)->first();
+        if (!$field) return;
+        Capsule::table('tblcustomfieldsvalues')->updateOrInsert(
+            ['fieldid' => $field->id, 'relid' => $serviceId],
+            ['value' => $value]
+        );
+    };
+
+    $results = []; // Per-field migration status for admin note
+
+    // 1. Migrate Tenant UUID
+    $existingTenantUUID = $getProductField('Tenant UUID');
+    if (empty($existingTenantUUID)) {
+        $clientTenantUUID = $getClientField('MultiPortal Tenant UUID');
+        if (!empty($clientTenantUUID)) {
+            $setProductField('Tenant UUID', $clientTenantUUID);
+            $migrated = true;
+            $results['Tenant UUID'] = 'success';
+        } else {
+            $results['Tenant UUID'] = 'not run (no legacy data found)';
+        }
+    } else {
+        $results['Tenant UUID'] = 'not run (already has value)';
+    }
+
+    // 2. Migrate Username
+    if (empty($hosting->username)) {
+        $clientUsername = $getClientField('MultiPortal Username');
+        if (!empty($clientUsername)) {
+            $results['Username'] = 'success';
+        } else {
+            $results['Username'] = 'not run (no legacy data found)';
+        }
+    } else {
+        $results['Username'] = 'not run (already has value)';
+    }
+
+    // 3. Migrate Password (together with username)
+    if (empty($hosting->username)) {
+        $passwordField = Capsule::table('tblcustomfields')
+            ->where('type', 'client')->where('fieldname', 'MultiPortal Password')->first();
+        $clientPassword = null;
+        if ($passwordField) {
+            $clientPassword = Capsule::table('tblcustomfieldsvalues')
+                ->where('fieldid', $passwordField->id)->where('relid', $clientId)->value('value');
+        }
+        $clientUsername = $getClientField('MultiPortal Username');
+        if (!empty($clientUsername) && !empty($clientPassword)) {
+            Capsule::table('tblhosting')->where('id', $serviceId)
+                ->update(['username' => $clientUsername, 'password' => $clientPassword]);
+            $migrated = true;
+            $results['Password'] = 'success';
+        } else {
+            $results['Password'] = 'not run (no legacy data found)';
+        }
+    } else {
+        $results['Password'] = 'not run (already has value)';
+    }
+
+    // 4. Migrate URL
+    $existingURL = $getProductField('URL');
+    if (empty($existingURL)) {
+        $clientURL = $getClientField('MultiPortal URL');
+        if (!empty($clientURL)) {
+            $setProductField('URL', $clientURL);
+            $migrated = true;
+            $results['URL'] = 'success';
+        } else {
+            $results['URL'] = 'not run (no legacy data found)';
+        }
+    } else {
+        $results['URL'] = 'not run (already has value)';
+    }
+
+    // 5. Migrate Last Usage Sync from relid=0 to per-product
+    $oldSyncField = Capsule::table('tblcustomfields')
+        ->where('type', 'product')->where('fieldname', 'Last Usage Sync')
+        ->where('relid', 0)->first();
+    $newSyncField = Capsule::table('tblcustomfields')
+        ->where('type', 'product')->where('fieldname', 'Last Usage Sync')
+        ->where('relid', $productId)->first();
+    if ($oldSyncField && $newSyncField) {
+        $oldValue = Capsule::table('tblcustomfieldsvalues')
+            ->where('fieldid', $oldSyncField->id)->where('relid', $serviceId)->value('value');
+        if (!empty($oldValue)) {
+            $newValue = Capsule::table('tblcustomfieldsvalues')
+                ->where('fieldid', $newSyncField->id)->where('relid', $serviceId)->value('value');
+            if (empty($newValue)) {
+                Capsule::table('tblcustomfieldsvalues')->updateOrInsert(
+                    ['fieldid' => $newSyncField->id, 'relid' => $serviceId],
+                    ['value' => $oldValue]
+                );
+                $migrated = true;
+                $results['Last Usage Sync'] = 'success';
+            } else {
+                $results['Last Usage Sync'] = 'not run (already has value)';
+            }
+            Capsule::table('tblcustomfieldsvalues')
+                ->where('fieldid', $oldSyncField->id)->where('relid', $serviceId)
+                ->update(['value' => '']);
+        } else {
+            $results['Last Usage Sync'] = 'not run (no legacy data found)';
+        }
+    } else {
+        $parts = [];
+        if (!$oldSyncField) $parts[] = 'old field missing';
+        if (!$newSyncField) $parts[] = 'new field missing';
+        $results['Last Usage Sync'] = 'not run (' . implode(', ', $parts) . ')';
+    }
+
+    // 6. Clear legacy client-level fields if we migrated anything
+    if ($migrated) {
+        $legacyFields = ['MultiPortal Tenant UUID', 'MultiPortal Username', 'MultiPortal Password', 'MultiPortal URL'];
+        foreach ($legacyFields as $legacyFieldName) {
+            $legacyField = Capsule::table('tblcustomfields')
+                ->where('type', 'client')->where('fieldname', $legacyFieldName)->first();
+            if ($legacyField) {
+                $legacyValue = Capsule::table('tblcustomfieldsvalues')
+                    ->where('fieldid', $legacyField->id)->where('relid', $clientId)->value('value');
+                if (!empty($legacyValue)) {
+                    Capsule::table('tblcustomfieldsvalues')
+                        ->where('fieldid', $legacyField->id)->where('relid', $clientId)
+                        ->update(['value' => '']);
+                }
+            }
+        }
+
+        // Write admin note with per-field results
+        $noteLines = [];
+        foreach ($results as $field => $status) {
+            $noteLines[] = "Migrated {$field}: {$status}";
+        }
+        $noteMessage = "AUTO-MODULE-DATA-MIGRATION: " . implode(', ', $noteLines);
+        if (function_exists('multiportal_appendAdminNote')) {
+            multiportal_appendAdminNote($serviceId, $noteMessage);
+        }
+
+        logActivity("MultiPortal AutoMigrate svc={$serviceId}: MIGRATED | " . implode('; ', $noteLines));
+    }
+
+    return $migrated;
+}
+
+/**
  * Add JavaScript confirmation for dangerous module actions
  */
 add_hook('AdminAreaFooterOutput', 1, function($vars) {
@@ -63,8 +272,30 @@ HTML;
  * Daily cron to sync usage data for all MultiPortal services
  */
 add_hook('DailyCronJob', 1, function() {
+    // Auto-migrate legacy data for all MultiPortal services
+    logActivity('MultiPortal: Checking for legacy data to migrate');
+    $allServices = Capsule::table('tblhosting as h')
+        ->join('tblservers as s', 'h.server', '=', 's.id')
+        ->where('s.type', 'multiportal')
+        ->whereIn('h.domainstatus', ['Active', 'Suspended'])
+        ->pluck('h.id');
+
+    $migratedCount = 0;
+    foreach ($allServices as $svcId) {
+        try {
+            if (multiportal_autoMigrateService($svcId)) {
+                $migratedCount++;
+            }
+        } catch (Exception $e) {
+            logActivity("MultiPortal: Auto-migration error for service ID {$svcId}: " . $e->getMessage());
+        }
+    }
+    if ($migratedCount > 0) {
+        logActivity("MultiPortal: Auto-migrated legacy data for {$migratedCount} service(s)");
+    }
+
     logActivity('MultiPortal Daily Usage Sync: Starting');
-    
+
     // Get all active MultiPortal services
     $services = Capsule::table('tblhosting as h')
         ->join('tblservers as s', 'h.server', '=', 's.id')
@@ -189,6 +420,9 @@ add_hook('AdminServiceEdit', 1, function($vars) {
         ->first();
     
     if ($service) {
+        // Note: Auto-migration moved to multiportal_AdminCustomButtonArray() in multiportal.php
+        // AdminServiceEdit fires on save, not page view, so it can't auto-migrate on view.
+
         // Trigger usage sync for this specific service
         try {
             $vdcUUID = getProductCustomFieldValue($serviceId, 'VDC UUID');

--- a/lib/CustomFieldFunctions.php
+++ b/lib/CustomFieldFunctions.php
@@ -4,13 +4,30 @@ use Illuminate\Database\Capsule\Manager as Capsule;
 
 /**
  * Utility: Set a custom field value for this service (e.g., VDC UUID)
+ *
+ * Looks up the field definition matching the service's product (relid = product ID).
+ * Falls back to relid = 0 if no product-specific field exists.
  */
 function setCustomFieldValue($serviceId, $fieldName, $value)
 {
-    $customField = Capsule::table('tblcustomfields')
-        ->where('type', 'product')
-        ->where('fieldname', $fieldName)
-        ->first();
+    $productId = Capsule::table('tblhosting')->where('id', $serviceId)->value('packageid');
+
+    // Prefer field matching the service's product, fall back to relid=0
+    $customField = null;
+    if ($productId) {
+        $customField = Capsule::table('tblcustomfields')
+            ->where('type', 'product')
+            ->where('fieldname', $fieldName)
+            ->where('relid', $productId)
+            ->first();
+    }
+    if (!$customField) {
+        $customField = Capsule::table('tblcustomfields')
+            ->where('type', 'product')
+            ->where('fieldname', $fieldName)
+            ->where('relid', 0)
+            ->first();
+    }
 
     if (!$customField) {
         throw new Exception("Custom field '$fieldName' not found.");

--- a/lib/ModuleConfiguration.php
+++ b/lib/ModuleConfiguration.php
@@ -14,7 +14,8 @@ class ModuleConfiguration
     const FIELD_PAYG_CPU_RATE = 4;
     const FIELD_PAYG_MEMORY_RATE = 5;
     const FIELD_PAYG_STORAGE_RATE = 6;
-    
+    const FIELD_ALLOCATION_TYPE = 7;
+
     // Server credential fields
     const FIELD_CLIENT_ID = 'serverusername';
     const FIELD_CLIENT_SECRET = 'serverpassword';
@@ -26,7 +27,8 @@ class ModuleConfiguration
         self::FIELD_RESELLER_UUID => 'Reseller UUID',
         self::FIELD_PAYG_CPU_RATE => 'PAYG CPU Rate',
         self::FIELD_PAYG_MEMORY_RATE => 'PAYG Memory Rate',
-        self::FIELD_PAYG_STORAGE_RATE => 'PAYG Storage Rate'
+        self::FIELD_PAYG_STORAGE_RATE => 'PAYG Storage Rate',
+        self::FIELD_ALLOCATION_TYPE => 'Allocation Type'
     ];
     
     /**
@@ -111,6 +113,7 @@ class ModuleConfiguration
             'payg_cpu_rate' => self::get($params, self::FIELD_PAYG_CPU_RATE, false) ?? 0.10,
             'payg_memory_rate' => self::get($params, self::FIELD_PAYG_MEMORY_RATE, false) ?? 0.05,
             'payg_storage_rate' => self::get($params, self::FIELD_PAYG_STORAGE_RATE, false) ?? 0.01,
+            'allocation_type' => self::get($params, self::FIELD_ALLOCATION_TYPE, false) ?? 'Allocation',
         ];
     }
     
@@ -153,17 +156,26 @@ class ModuleConfiguration
             $errors[] = $e->getMessage();
         }
         
-        // Validate configurable options
-        $cpu = isset($params['configoptions']['CPU']) ? (int)$params['configoptions']['CPU'] : 0;
-        $memory = isset($params['configoptions']['Memory Allocation']) ? (int)$params['configoptions']['Memory Allocation'] : 0;
-        
-        if ($cpu < 1 || $cpu > 128) {
-            $errors[] = 'CPU cores must be between 1 and 128 (currently: ' . $cpu . ')';
+        // Determine if this is a PAYG product (skip CPU/Memory validation for PAYG)
+        $allocationTypeKey = 'configoption' . self::FIELD_ALLOCATION_TYPE;
+        $isPayg = isset($params[$allocationTypeKey]) &&
+                  stripos($params[$allocationTypeKey], 'pay as you go') !== false;
+
+        if (!$isPayg) {
+            // Validate configurable options only for Allocation type products
+            $cpu = isset($params['configoptions']['CPU'])
+                ? (int)$params['configoptions']['CPU'] : 0;
+            $memory = isset($params['configoptions']['Memory Allocation'])
+                ? (int)$params['configoptions']['Memory Allocation'] : 0;
+
+            if ($cpu < 1 || $cpu > 128) {
+                $errors[] = 'CPU cores must be between 1 and 128 (currently: ' . $cpu . ')';
+            }
+            if ($memory < 1 || $memory > 512) {
+                $errors[] = 'Memory must be between 1 and 512 GB (currently: ' . $memory . ' GB)';
+            }
         }
-        if ($memory < 1 || $memory > 512) {
-            $errors[] = 'Memory must be between 1 and 512 GB (currently: ' . $memory . ' GB)';
-        }
-        
+
         return $errors;
     }
     

--- a/lib/TenantManager.php
+++ b/lib/TenantManager.php
@@ -95,12 +95,104 @@ class TenantManager
     
     public function getUsersByTenant($tenantId)
     {
-        $response = $this->api->get('/tenant/' . $tenantId . '/users');
-        
+        $response = $this->api->get('/tenant/' . $tenantId . '/user', ['pageSize' => 100]);
+
         if ($response['status'] === 'success') {
             return $response['data'];
         }
-        
+
         return [];
+    }
+
+    /**
+     * Find a user in a tenant by username or email.
+     *
+     * @return array|null User data or null if not found
+     */
+    public function findUserInTenant($tenantId, $username = null, $email = null)
+    {
+        // GET /tenant/{id}/user — note: singular "user", not "users"
+        $response = $this->api->get('/tenant/' . $tenantId . '/user', ['pageSize' => 100]);
+
+        if (function_exists('logModuleCall')) {
+            logModuleCall('multiportal', 'findUserInTenant_raw', [
+                'tenantId' => $tenantId,
+                'looking_for' => ['username' => $username, 'email' => $email],
+            ], json_encode($response), 'Raw API response for user list', []);
+        }
+
+        if (!isset($response['status']) || $response['status'] !== 'success' || empty($response['data'])) {
+            return null;
+        }
+
+        // API returns: { status: success, data: { data: [...users], count, page, pageSize } }
+        $userList = isset($response['data']['data']) ? $response['data']['data'] : [];
+
+        if (empty($userList)) {
+            return null;
+        }
+
+        foreach ($userList as $user) {
+            if (!is_array($user)) {
+                continue;
+            }
+            if ($username && isset($user['username']) && $user['username'] === $username) {
+                return $user;
+            }
+            if ($email && isset($user['email']) && strtolower($user['email']) === strtolower($email)) {
+                return $user;
+            }
+        }
+
+        if (function_exists('logModuleCall')) {
+            logModuleCall('multiportal', 'findUserInTenant_notfound', [
+                'looking_for' => ['username' => $username, 'email' => $email],
+                'user_count' => count($userList),
+                'usernames_in_list' => array_column($userList, 'username'),
+                'emails_in_list' => array_column($userList, 'email'),
+            ], '', 'User not found in list', []);
+        }
+
+        return null;
+    }
+
+    /**
+     * Update a user's password (and optionally other fields) in a tenant.
+     *
+     * The API requires ALL fields on PUT (not just changed ones), so we
+     * fetch the current user first and merge in the updates.
+     */
+    public function updateUser($tenantId, $userId, $data)
+    {
+        // Fetch current user data — PUT requires all fields
+        $current = $this->api->get('/tenant/' . $tenantId . '/user/' . $userId);
+
+        if (!isset($current['status']) || $current['status'] !== 'success' || empty($current['data'])) {
+            throw new Exception('Failed to fetch user for update: ' . json_encode($current));
+        }
+
+        $userData = $current['data'];
+        $payload = [
+            'username'        => isset($data['username']) ? $data['username'] : $userData['username'],
+            'email'           => isset($data['email']) ? $data['email'] : $userData['email'],
+            'first_name'      => isset($data['first_name']) ? $data['first_name'] : $userData['first_name'],
+            'last_name'       => isset($data['last_name']) ? $data['last_name'] : $userData['last_name'],
+            'role'            => isset($data['role']) ? $data['role'] : $userData['role'],
+            'status'          => isset($data['status']) ? $data['status'] : $userData['status'],
+        ];
+
+        // Only include password fields if provided
+        if (!empty($data['password'])) {
+            $payload['password'] = $data['password'];
+            $payload['confirmPassword'] = isset($data['confirmPassword']) ? $data['confirmPassword'] : $data['password'];
+        }
+
+        $response = $this->api->put('/tenant/' . $tenantId . '/user/' . $userId, $payload);
+
+        if ($response['status'] === 'success') {
+            return $response['data'];
+        }
+
+        throw new Exception('Failed to update user: ' . json_encode($response));
     }
 }

--- a/multiportal.php
+++ b/multiportal.php
@@ -28,7 +28,8 @@ function multiportal_MetaData()
 /**
  * Generate a secure password
  */
-function generateSecurePassword($length = 16) {
+function generateSecurePassword($length = 16)
+{
     // Ensure minimum length of 8
     $length = max(8, $length);
     
@@ -60,6 +61,63 @@ function generateSecurePassword($length = 16) {
 }
 
 /**
+ * Ensure per-product custom fields (Tenant UUID, URL) exist for a specific product.
+ *
+ * WHMCS only shows product custom fields on the service admin page when
+ * relid matches the product ID. This creates per-product field definitions
+ * so they appear alongside VDC UUID in the admin UI.
+ */
+function ensureProductCustomFields($productId)
+{
+    if (empty($productId)) {
+        return;
+    }
+
+    $fields = [
+        [
+            'fieldname' => 'Tenant UUID',
+            'description' => 'MultiPortal tenant identifier for this service',
+            'sortorder' => 1,
+        ],
+        [
+            'fieldname' => 'URL',
+            'description' => 'MultiPortal portal URL for this service',
+            'sortorder' => 2,
+        ],
+        [
+            'fieldname' => 'Last Usage Sync',
+            'description' => 'Last PAYG usage sync date',
+            'sortorder' => 3,
+        ],
+    ];
+
+    foreach ($fields as $field) {
+        $existing = Capsule::table('tblcustomfields')
+            ->where('type', 'product')
+            ->where('fieldname', $field['fieldname'])
+            ->where('relid', $productId)
+            ->first();
+
+        if (!$existing) {
+            Capsule::table('tblcustomfields')->insert([
+                'type' => 'product',
+                'relid' => $productId,
+                'fieldname' => $field['fieldname'],
+                'fieldtype' => 'text',
+                'description' => $field['description'],
+                'fieldoptions' => '',
+                'regexpr' => '',
+                'adminonly' => 'on',
+                'required' => '',
+                'showorder' => '',
+                'showinvoice' => '',
+                'sortorder' => $field['sortorder'],
+            ]);
+        }
+    }
+}
+
+/**
  * Ensure custom fields exist - create if missing
  */
 function ensureCustomFieldsExist()
@@ -67,27 +125,14 @@ function ensureCustomFieldsExist()
     $created = [];
 
     try {
+        // Only Tenant UUID remains at client level for backwards-compat fallback.
+        // Username/Password/URL are now stored per-service in product custom fields.
         $clientFields = [
             [
                 'fieldname' => 'MultiPortal Tenant UUID',
                 'fieldtype' => 'text',
                 'description' => 'Stores the MultiPortal tenant identifier',
                 'showorder' => 'on',
-            ],
-            [
-                'fieldname' => 'MultiPortal Username',
-                'fieldtype' => 'text',
-                'description' => 'Username for the MultiPortal tenant portal',
-            ],
-            [
-                'fieldname' => 'MultiPortal Password',
-                'fieldtype' => 'password',
-                'description' => 'Password for the MultiPortal tenant portal',
-            ],
-            [
-                'fieldname' => 'MultiPortal URL',
-                'fieldtype' => 'text',
-                'description' => 'URL for the MultiPortal tenant portal',
             ],
         ];
 
@@ -132,6 +177,43 @@ function ensureCustomFieldsExist()
     } catch (Exception $e) {
         throw new Exception('Error creating Virtual Data Center UUID field: ' . $e->getMessage());
     }
+
+    try {
+        // Product-level Tenant UUID and URL (per-service credential storage)
+        // relid=0 entries serve as fallbacks; per-product entries (created by
+        // ensureProductCustomFields) are what WHMCS displays in the admin UI.
+        $serviceFields = [
+            ['fieldname' => 'Tenant UUID', 'description' => 'MultiPortal tenant identifier for this service', 'sortorder' => 1],
+            ['fieldname' => 'URL', 'description' => 'MultiPortal portal URL for this service', 'sortorder' => 2],
+        ];
+        foreach ($serviceFields as $sf) {
+            $existing = Capsule::table('tblcustomfields')
+                ->where('type', 'product')
+                ->where('fieldname', $sf['fieldname'])
+                ->first();
+            if (!$existing) {
+                Capsule::table('tblcustomfields')->insert([
+                    'type' => 'product',
+                    'relid' => 0,
+                    'fieldname' => $sf['fieldname'],
+                    'fieldtype' => 'text',
+                    'description' => $sf['description'],
+                    'fieldoptions' => '',
+                    'regexpr' => '',
+                    'adminonly' => 'on',
+                    'required' => '',
+                    'showorder' => '',
+                    'showinvoice' => '',
+                    'sortorder' => $sf['sortorder'],
+                ]);
+                $created[] = 'Product field: ' . $sf['fieldname'];
+            }
+        }
+    } catch (Exception $e) {
+        throw new Exception('Error creating product credential fields: ' . $e->getMessage());
+    }
+
+    // Username/Password are stored in tblhosting.username/tblhosting.password (no custom fields needed).
 
     try {
         // Check and create delete confirmation field
@@ -187,6 +269,37 @@ function multiportal_log($action, $request, $response, $processedData = [], $rep
 }
 
 /**
+ * Append a timestamped entry to the service's Admin Notes field.
+ *
+ * Prepends the new entry so the most recent action is always at the top.
+ * Keeps at most $maxEntries log lines (oldest are trimmed).
+ */
+function multiportal_appendAdminNote($serviceId, $message, $maxEntries = 50)
+{
+    $timestamp = date('Y-m-d H:i:s');
+    $newEntry = "[$timestamp] $message";
+
+    $currentNotes = Capsule::table('tblhosting')
+        ->where('id', $serviceId)
+        ->value('notes');
+
+    if (!empty($currentNotes)) {
+        $lines = explode("\n", $currentNotes);
+        // Keep only the most recent entries
+        if (count($lines) >= $maxEntries) {
+            $lines = array_slice($lines, 0, $maxEntries - 1);
+        }
+        $notes = $newEntry . "\n" . implode("\n", $lines);
+    } else {
+        $notes = $newEntry;
+    }
+
+    Capsule::table('tblhosting')
+        ->where('id', $serviceId)
+        ->update(['notes' => $notes]);
+}
+
+/**
  * Validate required configuration options
  */
 function multiportal_validateConfig($params)
@@ -225,71 +338,9 @@ function multiportal_activate()
             ]);
         }
         
-        // Create client custom field for MultiPortal Username
-        $clientUsernameField = Capsule::table('tblcustomfields')
-            ->where('type', 'client')
-            ->where('fieldname', 'MultiPortal Username')
-            ->first();
-
-        if (!$clientUsernameField) {
-            Capsule::table('tblcustomfields')->insert([
-                'type' => 'client',
-                'fieldname' => 'MultiPortal Username',
-                'fieldtype' => 'text',
-                'description' => 'MultiPortal login username',
-                'fieldoptions' => '',
-                'regexpr' => '',
-                'adminonly' => 'on',
-                'required' => '',
-                'showorder' => 'on',
-                'showinvoice' => '',
-                'sortorder' => 0
-            ]);
-        }
-        
-        // Create client custom field for MultiPortal Password
-        $clientPasswordField = Capsule::table('tblcustomfields')
-            ->where('type', 'client')
-            ->where('fieldname', 'MultiPortal Password')
-            ->first();
-
-        if (!$clientPasswordField) {
-            Capsule::table('tblcustomfields')->insert([
-                'type' => 'client',
-                'fieldname' => 'MultiPortal Password',
-                'fieldtype' => 'password',
-                'description' => 'MultiPortal login password',
-                'fieldoptions' => '',
-                'regexpr' => '',
-                'adminonly' => 'on',
-                'required' => '',
-                'showorder' => 'on',
-                'showinvoice' => '',
-                'sortorder' => 0
-            ]);
-        }
-        
-        // Create client custom field for MultiPortal URL
-        $clientUrlField = Capsule::table('tblcustomfields')
-            ->where('type', 'client')
-            ->where('fieldname', 'MultiPortal URL')
-            ->first();
-
-        if (!$clientUrlField) {
-            Capsule::table('tblcustomfields')->insert([
-                'type' => 'client',
-                'fieldname' => 'MultiPortal URL',
-                'fieldtype' => 'text',
-                'description' => 'MultiPortal tenant URL',
-                'fieldoptions' => '',
-                'regexpr' => '',
-                'adminonly' => 'on',
-                'required' => '',
-                'showorder' => 'on',
-                'showinvoice' => '',
-                'sortorder' => 0
-            ]);
-        }
+        // Client-level Username/Password/URL fields are no longer created for new
+        // installs. Credentials are now stored per-service in product custom fields.
+        // Existing client-level fields remain accessible via the fallback chain.
 
         // Create product custom field for VDC UUID
         $productField = Capsule::table('tblcustomfields')
@@ -314,71 +365,35 @@ function multiportal_activate()
             ]);
         }
         
-        // Create product custom field for MultiPortal Username
-        $usernameField = Capsule::table('tblcustomfields')
-            ->where('type', 'product')
-            ->where('fieldname', 'MultiPortal Username')
-            ->first();
-        if (!$usernameField) {
-            Capsule::table('tblcustomfields')->insert([
-                'type' => 'product',
-                'fieldname' => 'MultiPortal Username',
-                'fieldtype' => 'text',
-                'description' => 'MultiPortal login username',
-                'fieldoptions' => '',
-                'regexpr' => '',
-                'adminonly' => 'on',
-                'required' => '',
-                'showorder' => '',
-                'showinvoice' => '',
-                'sortorder' => 1,
-                'relid' => 0
-            ]);
+        // Create product custom fields for Tenant UUID and URL (per-service)
+        $serviceFields = [
+            ['fieldname' => 'Tenant UUID', 'description' => 'MultiPortal tenant identifier for this service', 'sortorder' => 1],
+            ['fieldname' => 'URL', 'description' => 'MultiPortal portal URL for this service', 'sortorder' => 2],
+        ];
+        foreach ($serviceFields as $sf) {
+            $existing = Capsule::table('tblcustomfields')
+                ->where('type', 'product')
+                ->where('fieldname', $sf['fieldname'])
+                ->first();
+            if (!$existing) {
+                Capsule::table('tblcustomfields')->insert([
+                    'type' => 'product',
+                    'fieldname' => $sf['fieldname'],
+                    'fieldtype' => 'text',
+                    'description' => $sf['description'],
+                    'fieldoptions' => '',
+                    'regexpr' => '',
+                    'adminonly' => 'on',
+                    'required' => '',
+                    'showorder' => '',
+                    'showinvoice' => '',
+                    'sortorder' => $sf['sortorder'],
+                    'relid' => 0
+                ]);
+            }
         }
-        
-        // Create product custom field for MultiPortal Password
-        $passwordField = Capsule::table('tblcustomfields')
-            ->where('type', 'product')
-            ->where('fieldname', 'MultiPortal Password')
-            ->first();
-        if (!$passwordField) {
-            Capsule::table('tblcustomfields')->insert([
-                'type' => 'product',
-                'fieldname' => 'MultiPortal Password',
-                'fieldtype' => 'password',
-                'description' => 'MultiPortal login password',
-                'fieldoptions' => '',
-                'regexpr' => '',
-                'adminonly' => 'on',
-                'required' => '',
-                'showorder' => '',
-                'showinvoice' => '',
-                'sortorder' => 2,
-                'relid' => 0
-            ]);
-        }
-        
-        // Create product custom field for MultiPortal URL
-        $urlField = Capsule::table('tblcustomfields')
-            ->where('type', 'product')
-            ->where('fieldname', 'MultiPortal URL')
-            ->first();
-        if (!$urlField) {
-            Capsule::table('tblcustomfields')->insert([
-                'type' => 'product',
-                'fieldname' => 'MultiPortal URL',
-                'fieldtype' => 'text',
-                'description' => 'MultiPortal tenant URL',
-                'fieldoptions' => '',
-                'regexpr' => '',
-                'adminonly' => 'on',
-                'required' => '',
-                'showorder' => '',
-                'showinvoice' => '',
-                'sortorder' => 3,
-                'relid' => 0
-            ]);
-        }
+
+        // Username/Password are stored in tblhosting (no custom fields needed).
 
         return ['status' => 'success', 'description' => 'MultiPortal module activated successfully'];
     } catch (Exception $e) {
@@ -395,7 +410,7 @@ function multiportal_deactivate()
     // Uncomment below if you want to remove them on deactivation
 
     // Capsule::table('tblcustomfields')
-    //     ->whereIn('fieldname', ['MultiPortal Tenant UUID', 'VDC UUID'])
+    //     ->whereIn('fieldname', ['Tenant UUID', 'URL', 'VDC UUID'])
     //     ->delete();
 
     return ['status' => 'success', 'description' => 'MultiPortal module deactivated'];
@@ -435,10 +450,24 @@ function getClientCustomFieldValue($params, $fieldName)
  */
 function getProductCustomFieldValue($serviceId, $fieldName)
 {
-    $customField = Capsule::table('tblcustomfields')
-        ->where('type', 'product')
-        ->where('fieldname', $fieldName)
-        ->first();
+    $productId = Capsule::table('tblhosting')->where('id', $serviceId)->value('packageid');
+
+    // Prefer field matching the service's product, fall back to relid=0
+    $customField = null;
+    if ($productId) {
+        $customField = Capsule::table('tblcustomfields')
+            ->where('type', 'product')
+            ->where('fieldname', $fieldName)
+            ->where('relid', $productId)
+            ->first();
+    }
+    if (!$customField) {
+        $customField = Capsule::table('tblcustomfields')
+            ->where('type', 'product')
+            ->where('fieldname', $fieldName)
+            ->where('relid', 0)
+            ->first();
+    }
 
     if (!$customField) {
         return null;
@@ -501,6 +530,9 @@ function updateProductCustomFieldValue($serviceId, $fieldName, $fieldValue)
     return true;
 }
 
+/**
+ * Define module configuration options shown in WHMCS product settings.
+ */
 function multiportal_ConfigOptions($params)
 {
     // $clientId = $params['serverusername']; // set this in module settings
@@ -518,9 +550,107 @@ function multiportal_ConfigOptions($params)
         'PAYG CPU Rate ($/hour)' => ['Type' => 'text', 'Size' => '10', 'Default' => '0.10', 'Description' => 'Cost per CPU core per hour for PAYG'],
         'PAYG Memory Rate ($/GB/hour)' => ['Type' => 'text', 'Size' => '10', 'Default' => '0.05', 'Description' => 'Cost per GB of RAM per hour for PAYG'],
         'PAYG Storage Rate ($/GB/hour)' => ['Type' => 'text', 'Size' => '10', 'Default' => '0.01', 'Description' => 'Cost per GB of storage per hour for PAYG'],
+        'Allocation Type' => ['Type' => 'dropdown', 'Options' => 'Allocation,Pay As You Go', 'Default' => 'Allocation', 'Description' => 'Allocation = fixed resources, Pay As You Go = metered usage'],
     ];
 }
 
+/**
+ * Get allocation type as integer (1=Allocation, 2=PAYG).
+ *
+ * Primary: reads from module-level configoption7.
+ * Fallback: reads from configurable option dropdown
+ * for backwards compatibility with existing setups.
+ *
+ * @param array $params WHMCS module parameters
+ * @return int 1 for Allocation, 2 for Pay As You Go
+ */
+function multiportal_getAllocationType($params)
+{
+    // Primary: read from module-level configoption7
+    $setting = ModuleConfiguration::get($params, ModuleConfiguration::FIELD_ALLOCATION_TYPE, false);
+    if (!empty($setting)) {
+        return (stripos($setting, 'pay as you go') !== false) ? 2 : 1;
+    }
+    // Fallback: read from configurable option dropdown (backwards compat for existing setups)
+    if (isset($params['configoptions']['Allocation Type'])) {
+        $selected = $params['configoptions']['Allocation Type'];
+        if (stripos($selected, 'pay as you go') !== false || stripos($selected, 'payg') !== false) {
+            return 2;
+        }
+    }
+    return 1; // Default: Allocation
+}
+
+/**
+ * Get a MultiPortal custom field value with fallback from service-level to client-level.
+ *
+ * Used for Tenant UUID and URL lookups. Username/Password use tblhosting instead
+ * ($params['username']/$params['password']), not custom fields.
+ *
+ * @param string|null $clientFieldName Override for client-level field name (backwards compat).
+ *                                     E.g. 'Tenant UUID' at service level maps to
+ *                                     'MultiPortal Tenant UUID' at client level.
+ */
+function multiportal_getCredential($params, $fieldName, $clientFieldName = null)
+{
+    // 1. Service-level product custom field (primary)
+    if (isset($params['customfields'][$fieldName]) && !empty($params['customfields'][$fieldName])) {
+        return $params['customfields'][$fieldName];
+    }
+    $serviceValue = getProductCustomFieldValue($params['serviceid'], $fieldName);
+    if (!empty($serviceValue)) {
+        return $serviceValue;
+    }
+
+    // 2. Client-level custom field (backwards compat fallback)
+    $clientField = $clientFieldName ?: $fieldName;
+    $clientValue = getClientCustomFieldValue($params, $clientField);
+    if (!empty($clientValue)) {
+        return $clientValue;
+    }
+
+    return null;
+}
+
+/**
+ * Find existing MultiPortal credentials for a client on the same WHMCS server.
+ *
+ * When a client orders a second VDC on the same MultiPortal server, we reuse
+ * their existing tenant and user rather than creating duplicates.
+ *
+ * @return array|null Credential array or null if no existing service found
+ */
+function multiportal_findExistingCredentials($clientId, $serverId, $excludeServiceId = null)
+{
+    $query = Capsule::table('tblhosting')
+        ->where('userid', $clientId)
+        ->where('server', $serverId)
+        ->whereIn('domainstatus', ['Active', 'Suspended']);
+
+    if ($excludeServiceId) {
+        $query->where('id', '!=', $excludeServiceId);
+    }
+
+    $services = $query->get();
+
+    foreach ($services as $service) {
+        $tenantUUID = getProductCustomFieldValue($service->id, 'Tenant UUID');
+        if (!empty($tenantUUID) && !empty($service->username)) {
+            return [
+                'tenant_uuid' => $tenantUUID,
+                'username' => $service->username,
+                'password_encrypted' => $service->password,
+                'url' => getProductCustomFieldValue($service->id, 'URL'),
+            ];
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Define admin-area module command buttons and trigger auto-migration on page view.
+ */
 function multiportal_AdminCustomButtonArray($params)
 {
     $buttonarray = array();
@@ -557,35 +687,101 @@ function multiportal_AdminCustomButtonArray($params)
         $buttonarray['Setup Product Options'] = 'SetupWizard';
     }
 
-    if ($vdcId) {
-        // VDC exists, show update button
-        $buttonarray['Update'] = 'UpdateVDC';
+    // Show re-setup button when configurable options already exist,
+    // allowing admins to sync new storage policies from the data center
+    if (!empty($params['configoptions'])) {
+        $buttonarray['Re-Sync Storage Policies'] = 'ReSetupProductOptions';
+    }
 
-        // Get VDC status to show appropriate suspend/unsuspend button
+    if ($vdcId) {
         try {
             $api = initiateAPI($params);
             $vdcMgr = new VDCManager($api);
             $vdc = $vdcMgr->getVDCById($vdcId);
 
+            // User management (right after WHMCS standard Create button)
+            $buttonarray['Create/Reset User'] = 'CreateMultiPortalUser';
+            $buttonarray['Email Credentials'] = 'EmailCredentials';
+
+            // Re-sync storage policies (inside VDC block so it appears in order)
+            if (!empty($params['configoptions'])) {
+                // Remove the one added outside the block to control position
+                unset($buttonarray['Re-Sync Storage Policies']);
+                $buttonarray['Re-Sync Storage Policies'] = 'ReSetupProductOptions';
+            }
+
+            // Push/Pull data
+            $buttonarray['Push Config to MP'] = 'UpdateVDC';
+            $buttonarray['Pull Config from MP'] = 'SyncVDC';
+
+            // Usage & billing
+            $buttonarray["Show Current Month's Usage"] = 'ViewUsage';
+            $buttonarray["Show Last Month's Usage"] = 'ViewLastMonthUsage';
+            $buttonarray['Bill PayGo Usage'] = 'SyncUsageAndBill';
+
+            // Suspend/Unsuspend
             if ($vdc && isset($vdc['is_enabled'])) {
                 if ($vdc['is_enabled'] == 1) {
-                    $buttonarray['Suspend'] = 'DisableVdc';
+                    $buttonarray['Suspend VDC'] = 'DisableVdc';
                 } else {
-                    $buttonarray['Unsuspend'] = 'EnableVdc';
+                    $buttonarray['Unsuspend VDC'] = 'EnableVdc';
                 }
             }
 
-            $buttonarray['Sync Data'] = 'SyncVDC';
-            $buttonarray['View Usage'] = 'ViewUsage';
-            $buttonarray['Sync Usage & Bill'] = 'SyncUsageAndBill';
-            $buttonarray['Create/Reset User'] = 'CreateMultiPortalUser';
-            $buttonarray['Delete Virtual Data Center ⚠️'] = 'DestroyVdc';
+            // Destructive
+            $buttonarray['⚠️ Delete Virtual Data Center ⚠️'] = 'DestroyVdc';
         } catch (Exception $e) {
             // If we can't get VDC status, show both buttons
             multiportal_log('AdminCustomButtonArray', ['error' => $e->getMessage()], 'Failed to get Virtual Data Center status');
-            $buttonarray['Suspend'] = 'DisableVdc';
-            $buttonarray['Unsuspend'] = 'EnableVdc';
+            $buttonarray['Suspend VDC'] = 'DisableVdc';
+            $buttonarray['Unsuspend VDC'] = 'EnableVdc';
         }
+    }
+
+    // Auto-migrate legacy data on page view (transparent upgrade)
+    try {
+        $productId = Capsule::table('tblhosting')->where('id', $params['serviceid'])->value('packageid');
+        if ($productId) {
+            ensureProductCustomFields($productId);
+            multiportal_autoMigrateService($params['serviceid']);
+        }
+    } catch (Exception $e) {
+        // Silent fail - don't break button rendering
+    }
+
+    // Show "Migrate Credentials" when ANY legacy data exists:
+    // - Client-level Tenant UUID with no service-level Tenant UUID
+    // - Last Usage Sync in old relid=0 field with no per-product field value
+    $needsMigration = false;
+
+    $serviceTenantUUID = getProductCustomFieldValue($params['serviceid'], 'Tenant UUID');
+    if (empty($serviceTenantUUID)) {
+        $clientTenantUUID = getClientCustomFieldValue($params, 'MultiPortal Tenant UUID');
+        if (!empty($clientTenantUUID)) {
+            $needsMigration = true;
+        }
+    }
+
+    if (!$needsMigration) {
+        // Check for legacy Last Usage Sync (relid=0) with data for this service
+        $oldSyncField = Capsule::table('tblcustomfields')
+            ->where('type', 'product')
+            ->where('fieldname', 'Last Usage Sync')
+            ->where('relid', 0)
+            ->first();
+        if ($oldSyncField) {
+            $oldSyncValue = Capsule::table('tblcustomfieldsvalues')
+                ->where('fieldid', $oldSyncField->id)
+                ->where('relid', $params['serviceid'])
+                ->value('value');
+            if (!empty($oldSyncValue)) {
+                $needsMigration = true;
+            }
+        }
+    }
+
+    if ($needsMigration) {
+        $buttonarray['⬆️ MODULE UPGRADE (RUN MIGRATION!) ⬆️'] = 'MigrateCredentials';
     }
 
     return $buttonarray;
@@ -639,6 +835,9 @@ function multiportal_debugConfig($params, $action = 'Debug Config')
     ModuleConfiguration::debug($params);
 }
 
+/**
+ * Push local WHMCS configuration (CPU, RAM, storage policies) to the MultiPortal VDC.
+ */
 function multiportal_UpdateVDC(array $params)
 {
     try {
@@ -663,23 +862,30 @@ function multiportal_UpdateVDC(array $params)
         $res = $vdcMgr->getStoragePoliciesByDataCenter($dataCenterId);
         $storagePolicyConfig = verifyStoragePolicyOptions($params['configoptions'], $res);
 
-        // Determine allocation type from configurable option
-        $allocationType = 1; // Default to Allocation
-        if (isset($params['configoptions']['Allocation Type'])) {
-            $selectedType = $params['configoptions']['Allocation Type'];
-            // Convert the selection to allocation type ID
-            if (stripos($selectedType, 'pay as you go') !== false || stripos($selectedType, 'payg') !== false) {
-                $allocationType = 2;
-            }
+        // Determine allocation type (configoption7 with fallback to configurable option dropdown)
+        $allocationType = multiportal_getAllocationType($params);
+
+        // PAYG storage options are hidden (hidden=1) and WHMCS does not pass
+        // hidden configurable options through $params['configoptions'] during
+        // provisioning. Fall back to reading the config group from the DB.
+        if (empty($storagePolicyConfig) && $allocationType === 2) {
+            $storagePolicyConfig = getPaygStoragePoliciesFromDb($params['pid'], $res);
         }
+
+        // For PAYG, CPU/Memory are not selected by the client.
+        // API requires minimum 1 for both, so default to 1.
+        $cpu = isset($params['configoptions']['CPU'])
+            ? max(1, (int) $params['configoptions']['CPU']) : 1;
+        $memory = isset($params['configoptions']['Memory Allocation'])
+            ? max(1, (int) $params['configoptions']['Memory Allocation']) : 1;
 
         $vdc = $vdcMgr->updateVDC(
             $vdcId,
             [
                 'vdc_name' => 'VDC - ' . $params['serviceid'],
                 'allocation_type' => $allocationType,
-                'memory_in_gb' => (int) $params['configoptions']['Memory Allocation'],
-                'core_count' => (int) $params['configoptions']['CPU'],
+                'memory_in_gb' => $memory,
+                'core_count' => $cpu,
                 'is_enabled' => 1,
             ]
         );
@@ -700,36 +906,61 @@ function multiportal_UpdateVDC(array $params)
             $existingStoragePolicies[$storagePolicy['storage_policy_id']] = $storagePolicy;
         }
 
-        // Process storage policy updates
+        // Build a set of storage_policy_ids from the WHMCS config (capacity > 0)
+        $configPolicyIds = [];
+        foreach ($storagePolicyConfig as $config) {
+            $configPolicyIds[$config['storage_policy_id']] = true;
+        }
+
+        // Process storage policy updates: add new or update existing
         foreach ($storagePolicyConfig as $config) {
             $storagePolicyId = $config['storage_policy_id'];
             $capacity = (int) $config['capacity'];
 
             if (isset($existingStoragePolicies[$storagePolicyId])) {
+                // Update existing policy
                 $vdcStoragePolicyId = $existingStoragePolicies[$storagePolicyId]['uuid'];
-                if ($capacity === 0) {
-                    // Delete policy if capacity is 0
-                    $vdcMgr->deleteStoragePolicy($vdcId, $vdcStoragePolicyId);
-                } else {
-                    // Update existing policy
-                    $vdcMgr->updateStoragePolicy($vdcId, $vdcStoragePolicyId, [
-                        'storage_policy_id' => $storagePolicyId,
-                        'capacity' => $capacity,
-                    ]);
-                }
+                $vdcMgr->updateStoragePolicy($vdcId, $vdcStoragePolicyId, [
+                    'storage_policy_id' => $storagePolicyId,
+                    'capacity' => $capacity,
+                ]);
             } else {
-                if ($capacity > 0) {
-                    // Add new policy if it doesn't exist and capacity is positive
-                    $vdcMgr->addStoragePolicy($vdcId, [
-                        'storage_policy_id' => $storagePolicyId,
-                        'capacity' => $capacity,
-                    ]);
-                }
+                // Add new policy
+                $vdcMgr->addStoragePolicy($vdcId, [
+                    'storage_policy_id' => $storagePolicyId,
+                    'capacity' => $capacity,
+                ]);
             }
         }
 
+        // Remove VDC policies that are no longer in the WHMCS config (set to 0 or removed)
+        foreach ($existingStoragePolicies as $policyId => $policy) {
+            if (!isset($configPolicyIds[$policyId])) {
+                $vdcMgr->deleteStoragePolicy($vdcId, $policy['uuid']);
+            }
+        }
+
+        $policyNames = array_map(function ($p) { return $p['name'] . ' (' . $p['capacity'] . 'GB)'; }, $storagePolicyConfig);
+        $removedNames = [];
+        foreach ($existingStoragePolicies as $policyId => $policy) {
+            if (!isset($configPolicyIds[$policyId])) {
+                $removedNames[] = $policy['name'] ?? $policyId;
+            }
+        }
+        $pushNote = "Push Config to MP: ";
+        if ($allocationType !== 2) {
+            $pushNote .= "CPU: {$cpu}, RAM: {$memory}GB. ";
+        }
+        $pushNote .= "Storage: " . (empty($policyNames) ? 'none' : implode(', ', $policyNames));
+        if (!empty($removedNames)) {
+            $pushNote .= ". Removed: " . implode(', ', $removedNames);
+        }
+        multiportal_appendAdminNote($params['serviceid'], $pushNote);
+
         return 'success';
     } catch (Exception $e) {
+        multiportal_appendAdminNote($params['serviceid'],
+            "Push Config to MP ERROR: " . $e->getMessage());
         return 'Error: ' . $e->getMessage();
     }
 }
@@ -761,15 +992,10 @@ function multiportal_SyncVDC(array $params)
 
         multiportal_log('SyncVDC', ['vdcId' => $vdcId], $vdc, ['storagePolicies' => $storagePolicies]);
 
-        // Update service details with latest data (don't set domain to prevent IP/Website buttons)
-        $updateData = [
-            'notes' => "VDC Status: " . ($vdc['is_enabled'] ? 'Enabled' : 'Disabled') . "\n" .
-                "CPU Cores: " . $vdc['core_count'] . "\n" .
-                "Memory: " . $vdc['memory_in_gb'] . " GB\n" .
-                "Last Synced: " . date('Y-m-d H:i:s')
-        ];
+        $vdcStatus = $vdc['is_enabled'] ? 'Enabled' : 'Disabled';
 
         // Update service status based on VDC status
+        $updateData = [];
         if ($vdc['is_enabled'] == 1 && $params['status'] == 'Suspended') {
             $updateData['domainstatus'] = 'Active';
         } elseif ($vdc['is_enabled'] == 0 && $params['status'] == 'Active') {
@@ -777,9 +1003,21 @@ function multiportal_SyncVDC(array $params)
         }
 
         // Update service in WHMCS
-        Capsule::table('tblhosting')
-            ->where('id', $params['serviceid'])
-            ->update($updateData);
+        if (!empty($updateData)) {
+            Capsule::table('tblhosting')
+                ->where('id', $params['serviceid'])
+                ->update($updateData);
+        }
+
+        $pullPolicyNames = array_map(function ($p) {
+            return ($p['name'] ?? $p['storage_policy_name'] ?? 'Unknown') . ' (' . ($p['capacity'] ?? 0) . 'GB)';
+        }, $storagePolicies['data'] ?? []);
+        $pullNote = "Pull Config from MP: VDC {$vdcStatus}. ";
+        if (isset($vdc['allocation_type']) && $vdc['allocation_type'] != 2) {
+            $pullNote .= "CPU: {$vdc['core_count']}, RAM: {$vdc['memory_in_gb']}GB. ";
+        }
+        $pullNote .= "Storage: " . (empty($pullPolicyNames) ? 'none' : implode(', ', $pullPolicyNames));
+        multiportal_appendAdminNote($params['serviceid'], $pullNote);
 
         // Update configurable options to reflect actual VDC values
         // First, get the product's configurable options
@@ -896,14 +1134,21 @@ function multiportal_SyncVDC(array $params)
         return 'success';
     } catch (Exception $e) {
         multiportal_log('SyncVDC', $params, ['error' => $e->getMessage()]);
+        multiportal_appendAdminNote($params['serviceid'],
+            "Pull Config from MP ERROR: " . $e->getMessage());
         return 'Error: ' . $e->getMessage();
     }
 }
 
 /**
- * View VDC Usage
+ * Shared helper: fetch and log VDC usage for a given date range
+ *
+ * @param array  $params     WHMCS module params
+ * @param array  $dateRange  ['date_range' => 'YYYY/MM/DD HH:MM:SS - YYYY/MM/DD HH:MM:SS'] or empty for current month
+ * @param string $noteLabel  Label prefix for the admin note (e.g. "Current Month Usage")
+ * @return string 'success' or error message
  */
-function multiportal_ViewUsage(array $params)
+function multiportal_fetchUsage(array $params, array $dateRange, $noteLabel)
 {
     try {
         $api = initiateAPI($params);
@@ -914,60 +1159,90 @@ function multiportal_ViewUsage(array $params)
             throw new Exception('VDC UUID not found. Cannot view usage for non-existent VDC.');
         }
 
-        multiportal_log('ViewUsage', ['vdcId' => $vdcId], 'Fetching VDC usage');
+        multiportal_log('ViewUsage', ['vdcId' => $vdcId, 'label' => $noteLabel], 'Fetching VDC usage');
 
-        // Get VDC usage data
-        $usage = $vdcMgr->getVDCUsage($vdcId);
+        $usage = $vdcMgr->getVDCUsage($vdcId, $dateRange);
 
         multiportal_log('ViewUsage', ['vdcId' => $vdcId, 'usage_keys' => array_keys($usage ?? [])], $usage);
 
-        // Format the usage data for display
-        $message = "VDC Usage Statistics:\n\n";
+        // API returns: virtual_data_center, summary, usage_breakdown, formatted_usage, metadata
+        $formatted = $usage['formatted_usage'] ?? [];
+        $summary   = $usage['summary'] ?? [];
+        $status    = $formatted['current_status'] ?? [];
+        $resSummary = $formatted['resource_summary'] ?? [];
+        $vmStats   = $formatted['vm_statistics'] ?? [];
+        $storageSummary = $formatted['storage_summary'] ?? [];
+        $isPayg = isset($usage['virtual_data_center']['allocation_type']) && $usage['virtual_data_center']['allocation_type'] == 2;
 
-        // Debug: Show what keys are in the response
-        if (is_array($usage)) {
-            $message .= "Debug - Available data: " . implode(', ', array_keys($usage)) . "\n\n";
+        $period = ($summary['date_range']['start'] ?? '?') . ' to ' . ($summary['date_range']['end'] ?? '?');
+
+        // Build detailed admin note
+        $note = "{$noteLabel} ({$period}): ";
+        $note .= "VMs: " . ($status['running_vms'] ?? 'N/A') . " running";
+        if (isset($vmStats['total_runtime_hours'])) {
+            $note .= ", runtime: " . $vmStats['total_runtime_hours'] . "h";
+        }
+        $note .= ". ";
+
+        if (isset($resSummary['cpu'])) {
+            $cpu = $resSummary['cpu'];
+            $note .= "CPU: avg " . ($cpu['average_usage'] ?? 'N/A')
+                . ", total " . ($cpu['total_usage'] ?? 'N/A')
+                . ", daily " . ($cpu['daily_average'] ?? 'N/A') . ". ";
         }
 
-        if (isset($usage['cpu'])) {
-            $message .= "CPU Usage:\n";
-            $message .= "  - Used: " . ($usage['cpu']['used'] ?? 'N/A') . " cores\n";
-            $message .= "  - Allocated: " . ($usage['cpu']['allocated'] ?? 'N/A') . " cores\n";
-            $message .= "  - Usage: " . (isset($usage['cpu']['percentage']) ? $usage['cpu']['percentage'] . '%' : 'N/A') . "\n\n";
+        if (isset($resSummary['memory'])) {
+            $mem = $resSummary['memory'];
+            $note .= "RAM: avg " . ($mem['average_usage'] ?? 'N/A')
+                . ", total " . ($mem['total_usage'] ?? 'N/A')
+                . ", daily " . ($mem['daily_average'] ?? 'N/A') . ". ";
         }
 
-        if (isset($usage['memory'])) {
-            $message .= "Memory Usage:\n";
-            $message .= "  - Used: " . ($usage['memory']['used'] ?? 'N/A') . " GB\n";
-            $message .= "  - Allocated: " . ($usage['memory']['allocated'] ?? 'N/A') . " GB\n";
-            $message .= "  - Usage: " . (isset($usage['memory']['percentage']) ? $usage['memory']['percentage'] . '%' : 'N/A') . "\n\n";
-        }
-
-        if (isset($usage['storage']) && is_array($usage['storage'])) {
-            $message .= "Storage Usage:\n";
-            foreach ($usage['storage'] as $storage) {
-                $message .= "  - " . ($storage['policy_name'] ?? 'Unknown Policy') . ":\n";
-                $message .= "    • Used: " . ($storage['used'] ?? 'N/A') . " GB\n";
-                $message .= "    • Allocated: " . ($storage['allocated'] ?? 'N/A') . " GB\n";
-                $message .= "    • Usage: " . (isset($storage['percentage']) ? $storage['percentage'] . '%' : 'N/A') . "\n";
+        if (!empty($storageSummary)) {
+            $storageParts = [];
+            foreach ($storageSummary as $policyName => $info) {
+                $part = "{$policyName}: avg " . ($info['average_usage'] ?? 'N/A');
+                if (!$isPayg) {
+                    $part .= " / " . ($info['capacity'] ?? 'N/A')
+                        . " (" . ($info['utilization'] ?? 'N/A') . ")";
+                }
+                $storageParts[] = $part;
             }
+            $note .= "Storage: " . implode(', ', $storageParts);
         }
 
-        // Update service notes with usage information
-        $updateData = [
-            'notes' => "=== VDC Usage (Last Updated: " . date('Y-m-d H:i:s') . ") ===\n" . $message
-        ];
+        multiportal_appendAdminNote($params['serviceid'], $note);
 
-        Capsule::table('tblhosting')
-            ->where('id', $params['serviceid'])
-            ->update($updateData);
-
-        // Return success with message appended
-        return $message;
+        return 'success';
     } catch (Exception $e) {
         multiportal_log('ViewUsage', $params, ['error' => $e->getMessage()]);
+        multiportal_appendAdminNote($params['serviceid'],
+            "{$noteLabel} ERROR: " . $e->getMessage());
         return 'Error: ' . $e->getMessage();
     }
+}
+
+/**
+ * Show Current Month's Usage
+ */
+function multiportal_ViewUsage(array $params)
+{
+    return multiportal_fetchUsage($params, [], "Current Month Usage");
+}
+
+/**
+ * Show Last Month's Usage
+ */
+function multiportal_ViewLastMonthUsage(array $params)
+{
+    $dateFrom = date('Y/m/d 00:00:00', strtotime('first day of last month'));
+    $dateTo   = date('Y/m/d 23:59:59', strtotime('last day of last month'));
+
+    return multiportal_fetchUsage(
+        $params,
+        ['date_range' => $dateFrom . ' - ' . $dateTo],
+        "Last Month Usage"
+    );
 }
 
 /**
@@ -979,83 +1254,183 @@ function multiportal_CreateMultiPortalUser(array $params)
         $api = initiateAPI($params);
         $tenantMgr = new TenantManager($api);
         
-        // Get tenant UUID
-        $tenantUUID = getClientCustomFieldValue($params, 'MultiPortal Tenant UUID');
+        // Get tenant UUID (service-level 'Tenant UUID' → client-level 'MultiPortal Tenant UUID' fallback)
+        $tenantUUID = multiportal_getCredential($params, 'Tenant UUID', 'MultiPortal Tenant UUID');
         if (empty($tenantUUID)) {
             throw new Exception('Tenant UUID not found. Cannot create user without tenant.');
         }
-        
+
         // Get tenant details
         $tenant = $tenantMgr->findTenantById($tenantUUID);
         if (!$tenant) {
             throw new Exception('Tenant not found in MultiPortal.');
         }
-        
+
         multiportal_log('CreateMultiPortalUser', ['tenantUUID' => $tenantUUID], 'Starting user creation/reset');
-        
-        // Generate username from email
-        $emailParts = explode('@', $params['clientsdetails']['email']);
-        $baseUsername = $emailParts[0];
-        $multiportalUsername = $baseUsername . '_' . $params['serviceid'];
-        
+
         // Generate secure password
         $multiportalPassword = generateSecurePassword(16);
-        
-        // Create user in MultiPortal
-        $user = $tenantMgr->createUser(
-            $tenant['uuid'],
-            $multiportalUsername,
-            $multiportalPassword,
-            $params['clientsdetails']['email'],
-            $params['clientsdetails']['firstname'],
-            $params['clientsdetails']['lastname'],
-            'Tenant Administrator'
-        );
-        
-        // Store credentials in WHMCS service fields
+
+        // Check if this service already has a username (from a prior provisioning or reset).
+        // If so, find that user in MultiPortal and reset their password.
+        $currentUsername = !empty($params['username']) ? $params['username'] : '';
+        $clientEmail = $params['clientsdetails']['email'];
+
+        // Try to find an existing user by current username or email
+        $existingUser = $tenantMgr->findUserInTenant($tenant['uuid'], $currentUsername, $clientEmail);
+
+        if ($existingUser && !empty($existingUser['id'])) {
+            // User exists — reset their password
+            $multiportalUsername = $existingUser['username'];
+
+            $tenantMgr->updateUser($tenant['uuid'], $existingUser['id'], [
+                'password' => $multiportalPassword,
+                'confirmPassword' => $multiportalPassword,
+            ]);
+
+            $action = 'reset';
+            multiportal_log('CreateMultiPortalUser', [
+                'user_id' => $existingUser['id'],
+                'username' => $multiportalUsername,
+            ], 'Existing user found — password reset');
+        } else {
+            // No existing user found — create a new one
+            $emailParts = explode('@', $clientEmail);
+            $baseUsername = $emailParts[0];
+            $multiportalUsername = $baseUsername . '_' . $params['serviceid'];
+
+            $tenantMgr->createUser(
+                $tenant['uuid'],
+                $multiportalUsername,
+                $multiportalPassword,
+                $clientEmail,
+                $params['clientsdetails']['firstname'],
+                $params['clientsdetails']['lastname'],
+                'Tenant Administrator'
+            );
+
+            $action = 'created';
+        }
+
+        // Store credentials in tblhosting (for ClientArea $params['username']/$params['password'])
         Capsule::table('tblhosting')
             ->where('id', $params['serviceid'])
             ->update([
                 'username' => $multiportalUsername,
                 'password' => encrypt($multiportalPassword)
             ]);
-        
-        // Get MultiPortal URL from API configuration
-        $multiportalUrl = '';
-        $apiUrl = ModuleConfiguration::get($params, ModuleConfiguration::FIELD_API_URL);
-        if (!empty($apiUrl)) {
-            // Parse the API URL to get the base domain
-            $parsedUrl = parse_url($apiUrl);
-            if (isset($parsedUrl['host'])) {
-                $multiportalUrl = 'https://' . $parsedUrl['host'];
-            }
-        }
-        
-        // If empty, throw error
-        if (empty($multiportalUrl)) {
-            throw new Exception('MultiPortal URL could not be determined. Please check API Base URL in server configuration.');
-        }
-        
-        // Don't store URL in domain field to prevent WHMCS from showing IP/Website buttons
-        // The URL is available in the client area template instead
-        
+
         multiportal_log('CreateMultiPortalUser', [
+            'action' => $action,
             'username' => $multiportalUsername,
-            'url' => $multiportalUrl,
+            'service_id' => $params['serviceid'],
             'tenant' => $tenant['name']
-        ], 'User created/reset successfully');
-        
-        $message = "MultiPortal User Created/Reset Successfully\n\n";
-        $message .= "Username: " . $multiportalUsername . "\n";
-        $message .= "Password: " . $multiportalPassword . "\n";
-        $message .= "Portal URL: " . $multiportalUrl . "\n\n";
-        $message .= "These credentials have been stored in the service custom fields.";
-        
-        // Return success with message appended
-        return $message;
-        
+        ], "User $action successfully. Credentials stored in service record.");
+
+        multiportal_appendAdminNote($params['serviceid'],
+            "Create/Reset User: User {$action} — username '{$multiportalUsername}', tenant '{$tenant['name']}'");
+
+        return 'success';
+
     } catch (Exception $e) {
         multiportal_log('CreateMultiPortalUser', $params, ['error' => $e->getMessage()]);
+        multiportal_appendAdminNote($params['serviceid'],
+            "Create/Reset User ERROR: " . $e->getMessage());
+        return 'Error: ' . $e->getMessage();
+    }
+}
+
+/**
+ * Email the client their MultiPortal portal credentials.
+ *
+ * Sends two separate emails for security: one with the username and
+ * portal URL, another with the temporary password and a link to
+ * change it immediately.
+ */
+function multiportal_EmailCredentials(array $params)
+{
+    try {
+        // Get current credentials from the service record
+        $service = Capsule::table('tblhosting')->where('id', $params['serviceid'])->first();
+        if (!$service) {
+            throw new Exception('Service not found.');
+        }
+
+        $username = $service->username;
+        if (empty($username)) {
+            throw new Exception('No username set for this service. Run Create/Reset User first.');
+        }
+
+        // Decrypt the stored password
+        $password = decrypt($service->password);
+        if (empty($password)) {
+            throw new Exception('No password set for this service. Run Create/Reset User first.');
+        }
+
+        // Get portal URL from service custom field, fall back to deriving from API URL
+        $portalUrl = getProductCustomFieldValue($params['serviceid'], 'URL');
+        if (empty($portalUrl)) {
+            $apiUrl = ModuleConfiguration::get($params, ModuleConfiguration::FIELD_API_URL);
+            $portalUrl = rtrim($apiUrl, '/');
+            $portalUrl = preg_replace('#/api(/v\d+)?$#', '', $portalUrl);
+        }
+
+        // Get client info for the emails
+        $clientName = trim($params['clientsdetails']['firstname'] . ' ' . $params['clientsdetails']['lastname']);
+        $passwordChangeUrl = rtrim($portalUrl, '/') . '/user/profile#password';
+
+        // --- Email 1/2: Username ---
+        $usernameBody = '<p>Hello ' . htmlspecialchars($clientName) . ',</p>'
+            . '<p><b>Portal URL:</b> <a href="' . htmlspecialchars($portalUrl) . '">' . htmlspecialchars($portalUrl) . '</a><br>'
+            . '<b>Username:</b> ' . htmlspecialchars($username) . '</p>'
+            . '<p>Your <b>temporary</b> password will arrive in a separate email.</p>'
+            . '<p>If you have any questions, please don\'t hesitate to contact our support team.</p>';
+
+        $result1 = localAPI('SendEmail', [
+            'id' => $params['serviceid'],
+            'customtype' => 'product',
+            'customsubject' => 'Cloud Portal Credentials Reset (1/2) — Username',
+            'custommessage' => $usernameBody,
+        ]);
+
+        if ($result1['result'] !== 'success') {
+            throw new Exception('Failed to send username email: ' . ($result1['message'] ?? json_encode($result1)));
+        }
+
+        // --- Email 2/2: Temporary Password ---
+        $passwordBody = '<p>Hello ' . htmlspecialchars($clientName) . ',</p>'
+            . '<p><b>Temporary Password:</b> <code>' . htmlspecialchars($password) . '</code></p>'
+            . '<p>Please login at <a href="' . htmlspecialchars($passwordChangeUrl) . '">'
+            . htmlspecialchars($passwordChangeUrl) . '</a> and change your password right away.</p>'
+            . '<p><strong>After changing your password, please DELETE this email.</strong></p>';
+
+        $result2 = localAPI('SendEmail', [
+            'id' => $params['serviceid'],
+            'customtype' => 'product',
+            'customsubject' => 'Cloud Portal Credentials Reset (2/2) — TEMPORARY Password',
+            'custommessage' => $passwordBody,
+        ]);
+
+        if ($result2['result'] !== 'success') {
+            throw new Exception('Username email sent, but password email failed: ' . ($result2['message'] ?? json_encode($result2)));
+        }
+
+        multiportal_log('EmailCredentials', [
+            'service_id' => $params['serviceid'],
+            'client_id' => $params['userid'],
+            'username' => $username,
+            'email_to' => $params['clientsdetails']['email'],
+        ], 'Credentials emailed to client (2 emails)');
+
+        multiportal_appendAdminNote($params['serviceid'],
+            "Email Credentials: Sent 2 emails to {$params['clientsdetails']['email']} (username: {$username})");
+
+        return 'success';
+
+    } catch (Exception $e) {
+        multiportal_log('EmailCredentials', $params, ['error' => $e->getMessage()]);
+        multiportal_appendAdminNote($params['serviceid'],
+            "Email Credentials ERROR: " . $e->getMessage());
         return 'Error: ' . $e->getMessage();
     }
 }
@@ -1069,15 +1444,15 @@ function multiportal_CreateApiUser(array $params)
         $api = initiateAPI($params);
         $tenantMgr = new TenantManager($api);
         
-        // Get tenant UUID
-        $tenantUUID = getClientCustomFieldValue($params, 'MultiPortal Tenant UUID');
+        // Get tenant UUID (service-level 'Tenant UUID' → client-level 'MultiPortal Tenant UUID' fallback)
+        $tenantUUID = multiportal_getCredential($params, 'Tenant UUID', 'MultiPortal Tenant UUID');
         if (empty($tenantUUID)) {
             throw new Exception('Tenant UUID not found. Cannot create API user without tenant.');
         }
-        
-        // Check if API credentials already exist at client level
-        $existingApiUsername = getClientCustomFieldValue($params, 'MultiPortal API Username');
-        $existingApiPassword = getClientCustomFieldValue($params, 'MultiPortal API Password');
+
+        // Check if API credentials already exist
+        $existingApiUsername = multiportal_getCredential($params, 'MultiPortal API Username');
+        $existingApiPassword = multiportal_getCredential($params, 'MultiPortal API Password');
         
         if ($existingApiUsername && $existingApiPassword) {
             // API user already exists, return existing credentials
@@ -1223,9 +1598,33 @@ function multiportal_CreateApiUser(array $params)
             ]);
         }
         
-        // Store the API credentials at client level
-        setClientCustomFieldValue($params['userid'], 'MultiPortal API Username', $apiUsername);
-        setClientCustomFieldValue($params['userid'], 'MultiPortal API Password', $apiPassword);
+        // Store the API credentials at service level
+        // Create product-level fields if they don't exist
+        foreach (['MultiPortal API Username', 'MultiPortal API Password'] as $fname) {
+            $ftype = (strpos($fname, 'Password') !== false) ? 'password' : 'text';
+            $exists = Capsule::table('tblcustomfields')
+                ->where('type', 'product')
+                ->where('fieldname', $fname)
+                ->first();
+            if (!$exists) {
+                Capsule::table('tblcustomfields')->insert([
+                    'type' => 'product',
+                    'relid' => 0,
+                    'fieldname' => $fname,
+                    'fieldtype' => $ftype,
+                    'description' => 'API credentials for MultiPortal access',
+                    'fieldoptions' => '',
+                    'regexpr' => '',
+                    'adminonly' => 'on',
+                    'required' => '',
+                    'showorder' => '',
+                    'showinvoice' => '',
+                    'sortorder' => 10
+                ]);
+            }
+        }
+        setCustomFieldValue($params['serviceid'], 'MultiPortal API Username', $apiUsername);
+        setCustomFieldValue($params['serviceid'], 'MultiPortal API Password', $apiPassword);
         
         // Get tenant URL
         if (isset($tenant['domain']) && !empty($tenant['domain'])) {
@@ -1297,24 +1696,26 @@ function multiportal_SyncUsageAndBill(array $params)
         $billingStart = new DateTime($currentDate->format('Y-m-01'));
         $billingEnd = clone $currentDate;
 
-        // Check if we have a last sync date stored
+        // Ensure the Last Usage Sync field exists for this product
+        $productId = Capsule::table('tblhosting')->where('id', $params['serviceid'])->value('packageid');
+        ensureProductCustomFields($productId);
+
+        // Look up the field: prefer per-product (relid = productId), fall back to relid = 0
         $lastSyncField = Capsule::table('tblcustomfields')
             ->where('type', 'product')
             ->where('fieldname', 'Last Usage Sync')
+            ->where('relid', $productId)
             ->first();
 
         if (!$lastSyncField) {
-            // Create the custom field if it doesn't exist
-            $lastSyncFieldId = Capsule::table('tblcustomfields')->insertGetId([
-                'type' => 'product',
-                'fieldname' => 'Last Usage Sync',
-                'fieldtype' => 'text',
-                'description' => 'Last PAYG usage sync date',
-                'adminonly' => 'on'
-            ]);
-        } else {
-            $lastSyncFieldId = $lastSyncField->id;
+            $lastSyncField = Capsule::table('tblcustomfields')
+                ->where('type', 'product')
+                ->where('fieldname', 'Last Usage Sync')
+                ->where('relid', 0)
+                ->first();
         }
+
+        $lastSyncFieldId = $lastSyncField->id;
 
         // Get last sync date
         $lastSyncValue = Capsule::table('tblcustomfieldsvalues')
@@ -1694,27 +2095,31 @@ function multiportal_SyncUsageAndBill(array $params)
             }
         }
 
-        // Update service notes
-        $notes = "=== PAYG Usage Sync (Last Updated: " . date('Y-m-d H:i:s') . ") ===\n" . $message;
-        Capsule::table('tblhosting')
-            ->where('id', $params['serviceid'])
-            ->update(['notes' => $notes]);
+        multiportal_appendAdminNote($params['serviceid'],
+            "Bill PayGo Usage: " . ($totalCharge > 0
+                ? "Charges: \$" . number_format($totalCharge, 2) . ". Items created: " . ($createdItems ?? 0)
+                : "No usage charges for this period"));
 
         return $message;
     } catch (Exception $e) {
         multiportal_log('SyncUsageAndBill', $params, ['error' => $e->getMessage()]);
+        multiportal_appendAdminNote($params['serviceid'],
+            "Bill PayGo Usage ERROR: " . $e->getMessage());
         return 'Error: ' . $e->getMessage();
     }
 }
 
+/**
+ * Provision a new VDC: create tenant, user, VDC, and attach storage policies.
+ */
 function multiportal_CreateAccount(array $params)
 {
     try {
         // Check if VDC already exists
         $existingVdcId = isset($params['customfields']['VDC UUID']) ? $params['customfields']['VDC UUID'] : getProductCustomFieldValue($params['serviceid'], 'VDC UUID');
         if (!empty($existingVdcId)) {
-            multiportal_log('CreateAccount', ['vdc_id' => $existingVdcId], 'VDC already exists, skipping creation');
-            return 'success'; // VDC already exists, nothing to do
+            multiportal_log('CreateAccount', ['vdc_id' => $existingVdcId], 'VDC already exists, aborting');
+            return 'VDC UUID is already set (' . $existingVdcId . ') — VDC already exists.';
         }
         
         // Validate configuration
@@ -1736,6 +2141,16 @@ function multiportal_CreateAccount(array $params)
         $res = $vdcMgr->getStoragePoliciesByDataCenter($dataCenterId);
         $storagePolicyConfig = verifyStoragePolicyOptions($params['configoptions'], $res);
 
+        // Determine allocation type early — needed for storage fallback below
+        $allocationType = multiportal_getAllocationType($params);
+
+        // PAYG storage options are hidden (hidden=1) and WHMCS does not pass
+        // hidden configurable options through $params['configoptions'] during
+        // provisioning. Fall back to reading the config group from the DB.
+        if (empty($storagePolicyConfig) && $allocationType === 2) {
+            $storagePolicyConfig = getPaygStoragePoliciesFromDb($params['pid'], $res);
+        }
+
         // 1. Check Reseller
         $reseller = $resellerMgr->findResellerByID($resellerId);
         //throw error if reseller not found
@@ -1744,7 +2159,27 @@ function multiportal_CreateAccount(array $params)
         }
 
         // 2. Create/check Tenant
-        $tenantUUID = getClientCustomFieldValue($params, 'MultiPortal Tenant UUID');
+        // Ensure per-product Tenant UUID and URL fields exist so they show in admin UI
+        ensureProductCustomFields($params['pid']);
+        // Check service-level first, then same-server reuse, then client-level fallback
+        $tenantUUID = multiportal_getCredential($params, 'Tenant UUID', 'MultiPortal Tenant UUID');
+
+        // Remember if THIS service already had its own Tenant UUID before this run.
+        // Used later to decide whether $params['username'] is a real MultiPortal user
+        // or just a WHMCS auto-generated placeholder. Only checks service-level custom
+        // fields — client-level fallback doesn't count (means un-migrated, not provisioned).
+        $serviceAlreadyProvisioned = !empty($params['customfields']['Tenant UUID'] ?? '')
+            || !empty(getProductCustomFieldValue($params['serviceid'], 'Tenant UUID'));
+
+        // If no tenant found yet, check if another service on the same server has one
+        if (empty($tenantUUID)) {
+            $existingCreds = multiportal_findExistingCredentials(
+                $params['userid'], $params['serverid'], $params['serviceid']
+            );
+            if ($existingCreds && !empty($existingCreds['tenant_uuid'])) {
+                $tenantUUID = $existingCreds['tenant_uuid'];
+            }
+        }
 
         if (empty($tenantUUID)) {
             if (!empty($params['clientsdetails']['companyname']))
@@ -1759,112 +2194,161 @@ function multiportal_CreateAccount(array $params)
                 $params['clientsdetails']['firstname'] . ' ' . $params['clientsdetails']['lastname'],
                 $params['clientsdetails']['phonenumber']
             );
-            setClientCustomFieldValue($params['userid'], 'MultiPortal Tenant UUID', $tenant['uuid']);
+            // Store tenant UUID in service-level custom field
+            setCustomFieldValue($params['serviceid'], 'Tenant UUID', $tenant['uuid']);
         } else {
             $tenant = $tenantMgr->findTenantByID($tenantUUID);
+            // Ensure this service has the tenant UUID in its own custom field
+            setCustomFieldValue($params['serviceid'], 'Tenant UUID', $tenantUUID);
         }
 
         if (!$tenant) {
             throw new Exception('Failed to create or find tenant.');
         }
-        
-        // 2.5. Create user for the tenant if it doesn't exist (ONE USER PER CLIENT)
-        $multiportalUsername = '';
-        $multiportalPassword = '';
-        $multiportalUrl = '';
-        
-        // Check if client already has MultiPortal credentials
-        $existingUsername = getClientCustomFieldValue($params, 'MultiPortal Username');
-        $existingPassword = getClientCustomFieldValue($params, 'MultiPortal Password');
-        $existingUrl = getClientCustomFieldValue($params, 'MultiPortal URL');
-        
-        if (empty($existingUsername) || empty($existingPassword)) {
-            // Generate username from email (client-based, not service-based)
+
+        // 2.5. Create user for the tenant if it doesn't exist
+        // One user per client per MultiPortal server — reuse across services on same server
+        // Credentials stored in tblhosting.username/tblhosting.password (WHMCS native fields)
+
+        // WHMCS auto-generates a placeholder username from the domain when an order
+        // is submitted (e.g. "allocpr"), before CreateAccount runs. We must NOT treat
+        // this as a real MultiPortal user. Only trust $params['username'] if the
+        // service already had a Tenant UUID (meaning it was previously provisioned).
+        $existingUsername = ($serviceAlreadyProvisioned && !empty($params['username']))
+            ? $params['username'] : '';
+
+        // If not, check same-server sibling services
+        if (empty($existingUsername)) {
+            if (!isset($existingCreds)) {
+                $existingCreds = multiportal_findExistingCredentials(
+                    $params['userid'], $params['serverid'], $params['serviceid']
+                );
+            }
+            if ($existingCreds && !empty($existingCreds['username'])) {
+                $existingUsername = $existingCreds['username'];
+            }
+        }
+
+        // Also check client-level custom field as backwards-compat fallback
+        if (empty($existingUsername)) {
+            $existingUsername = getClientCustomFieldValue($params, 'MultiPortal Username');
+        }
+
+        if (empty($existingUsername)) {
+            // No existing credentials — create new user in MultiPortal
             $emailParts = explode('@', $params['clientsdetails']['email']);
             $baseUsername = $emailParts[0];
-            $multiportalUsername = $baseUsername . '_' . $params['userid']; // Use client ID instead of service ID
-            
-            // Generate secure password
+            $multiportalUsername = $baseUsername . '_' . $params['userid'];
             $multiportalPassword = generateSecurePassword(16);
-            
+
             try {
                 multiportal_log('CreateAccount', [
                     'tenant_uuid' => $tenant['uuid'],
                     'username' => $multiportalUsername,
                     'email' => $params['clientsdetails']['email'],
                     'client_id' => $params['userid']
-                ], 'Attempting to create user (client-based)');
-                
-                // Create user in MultiPortal
-                $user = $tenantMgr->createUser(
-                    $tenant['uuid'],
-                    $multiportalUsername,
-                    $multiportalPassword,
-                    $params['clientsdetails']['email'],
-                    $params['clientsdetails']['firstname'],
-                    $params['clientsdetails']['lastname'],
-                    'Tenant Administrator'
-                );
-                
-                multiportal_log('CreateAccount', ['user_response' => $user], 'User creation API response');
-                
-                // Get tenant URL - check if tenant has a domain field, otherwise construct it
-                if (isset($tenant['domain']) && !empty($tenant['domain'])) {
-                    $multiportalUrl = 'https://' . $tenant['domain'];
-                } else {
-                    // Fallback: construct from tenant name
-                    //$tenantName = strtolower(preg_replace('/[^a-zA-Z0-9]/', '', $tenant['name']));
-                    $multiportalUrl = 'https://' . $params['serverhostname'] . '/';
+                ], 'Attempting to create user');
+
+                try {
+                    $user = $tenantMgr->createUser(
+                        $tenant['uuid'],
+                        $multiportalUsername,
+                        $multiportalPassword,
+                        $params['clientsdetails']['email'],
+                        $params['clientsdetails']['firstname'],
+                        $params['clientsdetails']['lastname'],
+                        'Tenant Administrator'
+                    );
+                    multiportal_log('CreateAccount', ['user_response' => $user], 'User creation API response');
+                } catch (Exception $createEx) {
+                    $errorMsg = $createEx->getMessage();
+                    if (strpos($errorMsg, 'already been taken') !== false || strpos($errorMsg, '422') !== false) {
+                        // User already exists — find them and reset password
+                        $existingUser = $tenantMgr->findUserInTenant(
+                            $tenant['uuid'], $multiportalUsername, $params['clientsdetails']['email']
+                        );
+                        if ($existingUser && !empty($existingUser['id'])) {
+                            $multiportalUsername = $existingUser['username'];
+                            $tenantMgr->updateUser($tenant['uuid'], $existingUser['id'], [
+                                'password' => $multiportalPassword,
+                                'confirmPassword' => $multiportalPassword,
+                            ]);
+                            multiportal_log('CreateAccount', [
+                                'user_id' => $existingUser['id'],
+                                'username' => $multiportalUsername,
+                            ], 'Existing user found — password reset');
+                        } else {
+                            throw new Exception('User already exists but could not be found for password reset.');
+                        }
+                    } else {
+                        throw $createEx;
+                    }
                 }
-                
-                // Store credentials in CLIENT custom fields (not service fields)
-                setClientCustomFieldValue($params['userid'], 'MultiPortal Username', $multiportalUsername);
-                setClientCustomFieldValue($params['userid'], 'MultiPortal Password', $multiportalPassword);
-                setClientCustomFieldValue($params['userid'], 'MultiPortal URL', $multiportalUrl);
-                
+
+                // Store credentials in tblhosting (WHMCS passes these as $params['username']/$params['password'])
+                Capsule::table('tblhosting')
+                    ->where('id', $params['serviceid'])
+                    ->update([
+                        'username' => $multiportalUsername,
+                        'password' => encrypt($multiportalPassword)
+                    ]);
+
                 multiportal_log('CreateAccount', [
                     'username' => $multiportalUsername,
-                    'url' => $multiportalUrl,
-                    'client_id' => $params['userid']
-                ], 'Client credentials stored successfully');
+                    'service_id' => $params['serviceid']
+                ], 'Credentials stored in tblhosting');
             } catch (Exception $e) {
                 multiportal_log('CreateAccount', [
                     'error' => $e->getMessage(),
                     'trace' => $e->getTraceAsString(),
                     'client_id' => $params['userid']
                 ], 'Failed to create user - will retry later');
-                
-                // Continue with VDC creation even if user creation fails
             }
         } else {
-            // User already exists for this client
-            $multiportalUsername = $existingUsername;
-            $multiportalPassword = $existingPassword;
-            $multiportalUrl = $existingUrl;
-            
+            // Reuse existing credentials from same server — copy to this service's tblhosting
+            if ($existingCreds && !empty($existingCreds['password_encrypted'])) {
+                // Copy encrypted password directly from sibling service
+                Capsule::table('tblhosting')
+                    ->where('id', $params['serviceid'])
+                    ->update([
+                        'username' => $existingCreds['username'],
+                        'password' => $existingCreds['password_encrypted']
+                    ]);
+            }
+
             multiportal_log('CreateAccount', [
-                'username' => $multiportalUsername,
-                'client_id' => $params['userid']
-            ], 'Using existing client credentials');
-        }
-        
-        // 3. Create VDC
-        // Determine allocation type from configurable option
-        $allocationType = 1; // Default to Allocation
-        if (isset($params['configoptions']['Allocation Type'])) {
-            $selectedType = $params['configoptions']['Allocation Type'];
-            // Convert the selection to allocation type ID
-            if (stripos($selectedType, 'pay as you go') !== false || stripos($selectedType, 'payg') !== false) {
-                $allocationType = 2;
+                'username' => $existingUsername,
+                'service_id' => $params['serviceid']
+            ], 'Reusing existing credentials from same server');
+
+            // Copy URL from sibling service if available
+            if ($existingCreds && !empty($existingCreds['url'])) {
+                setCustomFieldValue($params['serviceid'], 'URL', $existingCreds['url']);
             }
         }
 
+        // Store portal URL in service-level custom field (derive from API URL)
+        $apiUrl = ModuleConfiguration::get($params, ModuleConfiguration::FIELD_API_URL);
+        if (!empty($apiUrl)) {
+            $portalUrl = rtrim($apiUrl, '/');
+            $portalUrl = preg_replace('#/api(/v\d+)?$#', '', $portalUrl);
+            setCustomFieldValue($params['serviceid'], 'URL', $portalUrl);
+        }
+
+        // 3. Create VDC
+        // For PAYG, CPU/Memory are not selected by the client.
+        // API requires minimum 1 for both, so default to 1.
+        $cpu = isset($params['configoptions']['CPU'])
+            ? max(1, (int) $params['configoptions']['CPU']) : 1;
+        $memory = isset($params['configoptions']['Memory Allocation'])
+            ? max(1, (int) $params['configoptions']['Memory Allocation']) : 1;
+
         $vdc = $vdcMgr->createVDC(
             'VDC - ' . $params['serviceid'],
-            $dataCenterId, // Use the variable we already got from ModuleConfiguration
+            $dataCenterId,
             $tenant['uuid'],
-            (int) $params['configoptions']['CPU'], // CPU
-            (int) $params['configoptions']['Memory Allocation'],  // RAM
+            $cpu,
+            $memory,
             true,
             $allocationType,
         );
@@ -1882,8 +2366,15 @@ function multiportal_CreateAccount(array $params)
             ]);
         }
 
+        $allocLabel = $allocationType === 2 ? 'PAYG' : 'Allocation';
+        multiportal_appendAdminNote($params['serviceid'],
+            "CreateAccount: VDC created ({$vdc['uuid']}). Tenant: {$tenant['name']} ({$tenant['uuid']}). "
+            . "Type: {$allocLabel}. CPU: {$cpu}, RAM: {$memory}GB. Storage policies: " . count($storagePolicyConfig));
+
         return 'success';
     } catch (Exception $e) {
+        multiportal_appendAdminNote($params['serviceid'],
+            "CreateAccount ERROR: " . $e->getMessage());
         return 'Error: ' . $e->getMessage();
     }
 }
@@ -1900,15 +2391,77 @@ function verifyStoragePolicyOptions($configOptions, $res)
     $storageConfig = [];
     foreach ($res['data'] as $storagePolicy) {
         $configOptionsFormat = "Storage - {$storagePolicy['name']}";
-        $storageQty = (int) $configOptions[$configOptionsFormat] ?? 0;
-        if (isset($configOptions[$configOptionsFormat])) {
+        if (!isset($configOptions[$configOptionsFormat])) {
+            continue;
+        }
+        $storageQty = (int) $configOptions[$configOptionsFormat];
+        if ($storageQty < 1) {
+            continue; // Skip policies with 0 capacity — not selected
+        }
+        $storageConfig[] = [
+            'name' => $storagePolicy['name'],
+            'storage_policy_id' => $storagePolicy['uuid'],
+            'capacity' => $storageQty,
+        ];
+    }
+    return $storageConfig;
+}
+
+/**
+ * Get PAYG storage policies from the database.
+ *
+ * Hidden configurable options (hidden=1) are not passed through in
+ * $params['configoptions'] by WHMCS during provisioning. For PAYG products
+ * whose storage options are hidden, this function reads the linked config
+ * group directly from the DB and returns policies where qtyminimum >= 1
+ * (i.e. admin has opted-in that policy for auto-provisioning).
+ *
+ * @param int   $productId         WHMCS product ID ($params['pid'])
+ * @param array $dcStoragePolicies API response from getStoragePoliciesByDataCenter()
+ * @return array Same format as verifyStoragePolicyOptions()
+ */
+function getPaygStoragePoliciesFromDb($productId, $dcStoragePolicies)
+{
+    $storageConfig = [];
+
+    // Find the linked MultiPortal config group for this product
+    $groupId = Capsule::table('tblproductconfiglinks')
+        ->join('tblproductconfiggroups', 'tblproductconfiglinks.gid', '=', 'tblproductconfiggroups.id')
+        ->where('tblproductconfiglinks.pid', $productId)
+        ->where('tblproductconfiggroups.name', 'LIKE', '%MultiPortal%')
+        ->value('tblproductconfiglinks.gid');
+
+    if (!$groupId) {
+        return $storageConfig;
+    }
+
+    // Get storage options from this group where admin set qtyminimum >= 1
+    $storageOptions = Capsule::table('tblproductconfigoptions')
+        ->where('gid', (int) $groupId)
+        ->where('optionname', 'LIKE', 'Storage - %')
+        ->where('qtyminimum', '>=', 1)
+        ->get();
+
+    // Build a lookup from policy name to API UUID
+    $policyLookup = [];
+    if (isset($dcStoragePolicies['data']) && is_array($dcStoragePolicies['data'])) {
+        foreach ($dcStoragePolicies['data'] as $policy) {
+            $policyLookup[$policy['name']] = $policy['uuid'];
+        }
+    }
+
+    foreach ($storageOptions as $option) {
+        // Extract policy name from "Storage - {name}"
+        $policyName = substr($option->optionname, strlen('Storage - '));
+        if (isset($policyLookup[$policyName])) {
             $storageConfig[] = [
-                'name' => $storagePolicy['name'],
-                'storage_policy_id' => $storagePolicy['uuid'],
-                'capacity' => $storageQty,
+                'name' => $policyName,
+                'storage_policy_id' => $policyLookup[$policyName],
+                'capacity' => max(1, (int) $option->qtyminimum),
             ];
         }
     }
+
     return $storageConfig;
 }
 
@@ -2209,9 +2762,14 @@ function multiportal_DisableVdc(array $params)
             ->where('id', $params['serviceid'])
             ->update(['domainstatus' => 'Suspended']);
 
+        multiportal_appendAdminNote($params['serviceid'],
+            "Suspend VDC: VDC {$vdcId} suspended. WHMCS status set to Suspended.");
+
         return 'success';
     } catch (Exception $e) {
         multiportal_log('DisableVdc', $params, ['error' => $e->getMessage()]);
+        multiportal_appendAdminNote($params['serviceid'],
+            "Suspend VDC ERROR: " . $e->getMessage());
         return 'Error: ' . $e->getMessage();
     }
 }
@@ -2248,12 +2806,21 @@ function multiportal_EnableVdc(array $params)
             ->where('id', $params['serviceid'])
             ->update(['domainstatus' => 'Active']);
 
+        multiportal_appendAdminNote($params['serviceid'],
+            "Unsuspend VDC: VDC {$vdcId} unsuspended. WHMCS status set to Active.");
+
         return 'success';
     } catch (Exception $e) {
         multiportal_log('EnableVdc', $params, ['error' => $e->getMessage()]);
+        multiportal_appendAdminNote($params['serviceid'],
+            "Unsuspend VDC ERROR: " . $e->getMessage());
         return 'Error: ' . $e->getMessage();
     }
 }
+
+/**
+ * Permanently delete a VDC after admin confirmation.
+ */
 function multiportal_DestroyVdc(array $params)
 {
     try {
@@ -2337,10 +2904,16 @@ function multiportal_DestroyVdc(array $params)
         multiportal_log('DestroyVdc', ['vdcId' => $vdcId], 'VDC deleted successfully');
 
         setCustomFieldValue($params['serviceid'], 'VDC UUID', '');
+
+        multiportal_appendAdminNote($params['serviceid'],
+            "DELETE VDC: VDC {$vdcId} permanently deleted. VDC UUID cleared.");
+
         return 'success';
     } catch (Exception $e) {
         // Clear confirmation on error
         unset($_SESSION['confirm_delete_vdc_' . $params['serviceid']]);
+        multiportal_appendAdminNote($params['serviceid'],
+            "DELETE VDC ERROR: " . $e->getMessage());
         return 'Error: ' . $e->getMessage();
     }
 }
@@ -2368,9 +2941,8 @@ function multiportal_cleanupConfirmations()
 function multiportal_SetupWizard(array $params)
 {
     try {
-        // First, validate API credentials and test connection
+        // Validate API credentials and test connection
         try {
-            // Debug: Log what params we're receiving
             multiportal_log('SetupWizard', [
                 'params_keys' => array_keys($params),
                 'has_serverusername' => isset($params['serverusername']),
@@ -2379,32 +2951,25 @@ function multiportal_SetupWizard(array $params)
                 'server_id' => $params['serverid'] ?? 'NO SERVER ID',
                 'product_id' => $params['pid'] ?? 'NO PRODUCT ID'
             ], 'Debug: Checking params structure');
-            
-            // Check if credentials are configured
+
             $clientId = ModuleConfiguration::getClientId($params);
             $clientSecret = ModuleConfiguration::getClientSecret($params);
-            
-            // Test API connection
+
             $api = initiateAPI($params);
-            
-            // Skip the reseller test - we'll validate with the data center check below
+
             multiportal_log('SetupWizard', ['action' => 'API initialized'], 'API client created');
-            
+
         } catch (Exception $e) {
-            $serverId = $params['serverid'] ?? 'unknown';
-            
-            // Simple error message
             if (strpos($e->getMessage(), 'Client ID') !== false || strpos($e->getMessage(), 'Client Secret') !== false) {
                 return 'Error: Server credentials are empty. Go to System Settings > Servers and edit the Multiportal Server to add your API credentials.';
             }
-            
             return 'Error: ' . $e->getMessage();
         }
-        
-        // Now ensure custom fields exist
-        $customFieldsCreated = [];
+
+        // Ensure custom fields exist
         try {
-            $customFieldsCreated = ensureCustomFieldsExist();
+            ensureCustomFieldsExist();
+            ensureProductCustomFields($params['pid']);
         } catch (Exception $e) {
             return 'Error creating custom fields: ' . $e->getMessage();
         }
@@ -2416,18 +2981,19 @@ function multiportal_SetupWizard(array $params)
             throw new Exception('Data Center UUID must be configured in the product module settings first.');
         }
 
-        // Validate that the Data Center UUID exists
+        // Validate Data Center UUID
         try {
             $dataCenterResponse = $api->get('/data-center/' . $dataCenterId);
             if (!$dataCenterResponse || !isset($dataCenterResponse['data'])) {
                 throw new Exception('Data Center UUID is invalid or not found.');
             }
-            multiportal_log('SetupWizard', ['datacenter' => $dataCenterResponse['data']['name'] ?? 'Unknown'], 'Data Center validated');
+            $dataCenterName = $dataCenterResponse['data']['name'] ?? 'Unknown';
+            multiportal_log('SetupWizard', ['datacenter' => $dataCenterName], 'Data Center validated');
         } catch (Exception $e) {
             return 'Data Center Validation Error: ' . $e->getMessage() . ' Please check the Data Center UUID in module settings.';
         }
 
-        // Create product-specific custom fields
+        // Create product-specific VDC UUID custom field
         $vdcField = Capsule::table('tblcustomfields')
             ->where('type', 'product')
             ->where('relid', $productId)
@@ -2437,7 +3003,7 @@ function multiportal_SetupWizard(array $params)
         if (!$vdcField) {
             Capsule::table('tblcustomfields')->insert([
                 'type' => 'product',
-                'relid' => $productId,  // THIS IS THE KEY - specific to this product!
+                'relid' => $productId,
                 'fieldname' => 'VDC UUID',
                 'fieldtype' => 'text',
                 'description' => 'Stores the Virtual Data Center identifier',
@@ -2449,48 +3015,52 @@ function multiportal_SetupWizard(array $params)
                 'showinvoice' => '',
                 'sortorder' => 0
             ]);
-            $customFieldsCreated[] = 'Product field: Virtual Data Center UUID (for product ' . $productId . ')';
         }
 
-        // Check if a configurable option group already exists for this product
-        $existingGroup = Capsule::table('tblproductconfiglinks')
+        // Determine this product's allocation type from configoption7
+        $allocationType = multiportal_getAllocationType($params);
+        $isPayg = ($allocationType === 2);
+
+        multiportal_log('SetupWizard', [
+            'allocation_type' => $allocationType,
+            'is_payg' => $isPayg,
+            'configoption7' => $params['configoption7'] ?? 'NOT SET'
+        ], 'Allocation type determined');
+
+        // Check if this product already has a MultiPortal config group linked
+        $existingLink = Capsule::table('tblproductconfiglinks')
             ->join('tblproductconfiggroups', 'tblproductconfiglinks.gid', '=', 'tblproductconfiggroups.id')
             ->where('tblproductconfiglinks.pid', $productId)
             ->where('tblproductconfiggroups.name', 'LIKE', '%MultiPortal%')
             ->first();
 
-        if ($existingGroup) {
-            return 'Configurable options already exist for this product. Group: ' . $existingGroup->name;
+        if ($existingLink) {
+            // If the linked group has options, it's fully set up — nothing to do
+            $linkedOptionCount = Capsule::table('tblproductconfigoptions')
+                ->where('gid', $existingLink->gid)
+                ->count();
+            if ($linkedOptionCount > 0) {
+                return 'Configurable options already exist for this product. Group: ' . $existingLink->name;
+            }
+            // Otherwise the group is empty (e.g. PAYG group missing marker option) —
+            // remove the link so the wizard can re-run and backfill properly
+            Capsule::table('tblproductconfiglinks')
+                ->where('pid', $productId)
+                ->where('gid', $existingLink->gid)
+                ->delete();
+            multiportal_log('SetupWizard', [
+                'product_id' => $productId,
+                'empty_group' => $existingLink->name
+            ], 'Removed link to empty config group, re-running wizard');
         }
 
-        // Create a new configurable option group
-        $groupName = 'MultiPortal Options - Product ' . $productId;
-        Capsule::table('tblproductconfiggroups')->insert([
-            'name' => $groupName,
-            'description' => 'Auto-generated MultiPortal configurable options'
-        ]);
-        $groupId = Capsule::getPdo()->lastInsertId();
-
-        // Link the group to this product
-        Capsule::table('tblproductconfiglinks')->insert([
-            'gid' => $groupId,
-            'pid' => $productId
-        ]);
-
+        // --- Pricing helper ---
         $currencies = Capsule::table('tblcurrencies')->select('id')->get();
         $pricingTemplate = [
-            'msetupfee' => '0.00',
-            'qsetupfee' => '0.00',
-            'ssetupfee' => '0.00',
-            'asetupfee' => '0.00',
-            'bsetupfee' => '0.00',
-            'tsetupfee' => '0.00',
-            'monthly' => '0.00',
-            'quarterly' => '0.00',
-            'semiannually' => '0.00',
-            'annually' => '0.00',
-            'biennially' => '0.00',
-            'triennially' => '0.00'
+            'msetupfee' => '0.00', 'qsetupfee' => '0.00', 'ssetupfee' => '0.00',
+            'asetupfee' => '0.00', 'bsetupfee' => '0.00', 'tsetupfee' => '0.00',
+            'monthly' => '0.00', 'quarterly' => '0.00', 'semiannually' => '0.00',
+            'annually' => '0.00', 'biennially' => '0.00', 'triennially' => '0.00'
         ];
         $ensurePricing = function (int $relId) use ($currencies, $pricingTemplate) {
             foreach ($currencies as $currency) {
@@ -2499,7 +3069,6 @@ function multiportal_SetupWizard(array $params)
                     ->where('currency', $currency->id)
                     ->where('relid', $relId)
                     ->first();
-
                 if (!$existing) {
                     Capsule::table('tblpricing')->insert(array_merge([
                         'type' => 'configoptions',
@@ -2510,62 +3079,71 @@ function multiportal_SetupWizard(array $params)
             }
         };
 
-        // Create CPU option
-        Capsule::table('tblproductconfigoptions')->insert([
-            'gid' => $groupId,
-            'optionname' => 'CPU',
-            'optiontype' => 4, // Quantity
-            'qtyminimum' => 1,
-            'qtymaximum' => 128,
-            'order' => 1,
-            'hidden' => 0
-        ]);
-        $cpuOptionId = Capsule::getPdo()->lastInsertId();
-
-        // Create sub-option for CPU
-        Capsule::table('tblproductconfigoptionssub')->insert([
-            'configid' => $cpuOptionId,
-            'optionname' => 'CPU Core',
-            'sortorder' => 0,
-            'hidden' => 0
-        ]);
-        $cpuSubOptionId = (int) Capsule::getPdo()->lastInsertId();
-        $ensurePricing($cpuSubOptionId);
-
-        // Create Memory option
-        Capsule::table('tblproductconfigoptions')->insert([
-            'gid' => $groupId,
-            'optionname' => 'Memory Allocation',
-            'optiontype' => 4, // Quantity
-            'qtyminimum' => 1,
-            'qtymaximum' => 512,
-            'order' => 2,
-            'hidden' => 0
-        ]);
-        $memoryOptionId = Capsule::getPdo()->lastInsertId();
-
-        // Create sub-option for Memory
-        Capsule::table('tblproductconfigoptionssub')->insert([
-            'configid' => $memoryOptionId,
-            'optionname' => 'GB',
-            'sortorder' => 0,
-            'hidden' => 0
-        ]);
-        $memorySubOptionId = (int) Capsule::getPdo()->lastInsertId();
-        $ensurePricing($memorySubOptionId);
-
-        // Fetch storage policies from the data center
-        $api = initiateAPI($params);
+        // Fetch storage policies from the data center (needed for both groups)
         $vdcMgr = new VDCManager($api);
         $storagePolicies = $vdcMgr->getStoragePoliciesByDataCenter($dataCenterId);
+        $storagePolicyData = (isset($storagePolicies['data']) && is_array($storagePolicies['data']))
+            ? $storagePolicies['data'] : [];
 
-        if (isset($storagePolicies['data']) && is_array($storagePolicies['data'])) {
+        // =====================================================================
+        // GROUP 1: MultiPortal Allocation Options (per data center)
+        // =====================================================================
+        $allocationGroupName = 'MultiPortal Allocation Options - ' . $dataCenterName;
+        $allocationGroup = Capsule::table('tblproductconfiggroups')
+            ->where('name', $allocationGroupName)
+            ->first();
+
+        if (!$allocationGroup) {
+            Capsule::table('tblproductconfiggroups')->insert([
+                'name' => $allocationGroupName,
+                'description' => 'Auto-generated MultiPortal options for Allocation type products (CPU, Memory, Storage)'
+            ]);
+            $allocationGroupId = (int) Capsule::getPdo()->lastInsertId();
+
+            // CPU option
+            Capsule::table('tblproductconfigoptions')->insert([
+                'gid' => $allocationGroupId,
+                'optionname' => 'CPU',
+                'optiontype' => 4, // Quantity
+                'qtyminimum' => 1,
+                'qtymaximum' => 128,
+                'order' => 1,
+                'hidden' => 0
+            ]);
+            $cpuOptionId = Capsule::getPdo()->lastInsertId();
+            Capsule::table('tblproductconfigoptionssub')->insert([
+                'configid' => $cpuOptionId,
+                'optionname' => 'CPU Core',
+                'sortorder' => 0,
+                'hidden' => 0
+            ]);
+            $ensurePricing((int) Capsule::getPdo()->lastInsertId());
+
+            // Memory option
+            Capsule::table('tblproductconfigoptions')->insert([
+                'gid' => $allocationGroupId,
+                'optionname' => 'Memory Allocation',
+                'optiontype' => 4, // Quantity
+                'qtyminimum' => 1,
+                'qtymaximum' => 512,
+                'order' => 2,
+                'hidden' => 0
+            ]);
+            $memoryOptionId = Capsule::getPdo()->lastInsertId();
+            Capsule::table('tblproductconfigoptionssub')->insert([
+                'configid' => $memoryOptionId,
+                'optionname' => 'GB',
+                'sortorder' => 0,
+                'hidden' => 0
+            ]);
+            $ensurePricing((int) Capsule::getPdo()->lastInsertId());
+
+            // Storage policy options
             $order = 3;
-            foreach ($storagePolicies['data'] as $policy) {
+            foreach ($storagePolicyData as $policy) {
                 if (!empty($policy['name'])) {
-                    // Create storage policy option
                     Capsule::table('tblproductconfigoptions')->insert([
-                        'gid' => $groupId,
+                        'gid' => $allocationGroupId,
                         'optionname' => 'Storage - ' . $policy['name'],
                         'optiontype' => 4, // Quantity
                         'qtyminimum' => 0,
@@ -2574,84 +3152,480 @@ function multiportal_SetupWizard(array $params)
                         'hidden' => 0
                     ]);
                     $storageOptionId = Capsule::getPdo()->lastInsertId();
-
-                    // Create sub-option for storage
                     Capsule::table('tblproductconfigoptionssub')->insert([
                         'configid' => $storageOptionId,
                         'optionname' => 'GB',
                         'sortorder' => 0,
                         'hidden' => 0
                     ]);
-                    $storageSubOptionId = (int) Capsule::getPdo()->lastInsertId();
-                    $ensurePricing($storageSubOptionId);
+                    $ensurePricing((int) Capsule::getPdo()->lastInsertId());
                 }
             }
+
+            multiportal_log('SetupWizard', ['group_id' => $allocationGroupId], 'Created Allocation Options group');
+        } else {
+            $allocationGroupId = (int) $allocationGroup->id;
+            multiportal_log('SetupWizard', ['group_id' => $allocationGroupId], 'Allocation Options group already exists');
         }
 
-        // Optional: Create Allocation Type dropdown
-        Capsule::table('tblproductconfigoptions')->insert([
-            'gid' => $groupId,
-            'optionname' => 'Allocation Type',
-            'optiontype' => 1, // Dropdown
-            'qtyminimum' => 0,
-            'qtymaximum' => 0,
-            'order' => 100,
-            'hidden' => 0
-        ]);
-        $allocationOptionId = Capsule::getPdo()->lastInsertId();
+        // =====================================================================
+        // GROUP 2: MultiPortal PAYG Options (per data center)
+        // =====================================================================
+        $paygGroupName = 'MultiPortal PAYG Options - ' . $dataCenterName;
+        $paygGroup = Capsule::table('tblproductconfiggroups')
+            ->where('name', $paygGroupName)
+            ->first();
 
-        multiportal_log('SetupWizard', ['allocation_option_id' => $allocationOptionId], 'Created Allocation Type option');
+        if (!$paygGroup) {
+            Capsule::table('tblproductconfiggroups')->insert([
+                'name' => $paygGroupName,
+                'description' => 'Auto-generated MultiPortal options for Pay As You Go products (Storage)'
+            ]);
+            $paygGroupId = (int) Capsule::getPdo()->lastInsertId();
 
-        // Create allocation type sub-options
-        $allocationTypes = ['Allocation', 'Pay As You Go'];
-        foreach ($allocationTypes as $index => $type) {
-            // Check if sub-option already exists
-            $exists = Capsule::table('tblproductconfigoptionssub')
-                ->where('configid', $allocationOptionId)
-                ->where('optionname', $type)
-                ->first();
+            // WHMCS requires at least one option in a config group for the product
+            // to be recognized as having configurable options set up. Add a hidden
+            // marker option that is invisible to clients on the order page.
+            Capsule::table('tblproductconfigoptions')->insert([
+                'gid' => $paygGroupId,
+                'optionname' => 'MP_INIT_FLAG',
+                'optiontype' => 2, // Radio
+                'qtyminimum' => 0,
+                'qtymaximum' => 0,
+                'order' => 1,
+                'hidden' => 1
+            ]);
+            $paygMarkerOptionId = Capsule::getPdo()->lastInsertId();
+            Capsule::table('tblproductconfigoptionssub')->insert([
+                'configid' => $paygMarkerOptionId,
+                'optionname' => 'Enabled',
+                'sortorder' => 0,
+                'hidden' => 0
+            ]);
+            $ensurePricing((int) Capsule::getPdo()->lastInsertId());
 
-            if (!$exists) {
-                Capsule::table('tblproductconfigoptionssub')->insert([
-                    'configid' => $allocationOptionId,
-                    'optionname' => $type,
-                    'sortorder' => $index,
-                    'hidden' => 0
-                ]);
-                $allocationSubId = (int) Capsule::getPdo()->lastInsertId();
-                multiportal_log('SetupWizard', ['sub_option' => $type, 'index' => $index], 'Created sub-option');
-            } else {
-                $allocationSubId = (int) $exists->id;
+            // Storage policy options — hidden from clients, admin-only.
+            // Default 0 (not provisioned). Admin sets qtyminimum=1 on
+            // specific policies to always attach them during provisioning.
+            $paygOrder = 2;
+            foreach ($storagePolicyData as $policy) {
+                if (!empty($policy['name'])) {
+                    Capsule::table('tblproductconfigoptions')->insert([
+                        'gid' => $paygGroupId,
+                        'optionname' => 'Storage - ' . $policy['name'],
+                        'optiontype' => 4, // Quantity
+                        'qtyminimum' => 0,
+                        'qtymaximum' => 10000,
+                        'order' => $paygOrder++,
+                        'hidden' => 1
+                    ]);
+                    $storageOptionId = Capsule::getPdo()->lastInsertId();
+                    Capsule::table('tblproductconfigoptionssub')->insert([
+                        'configid' => $storageOptionId,
+                        'optionname' => 'GB',
+                        'sortorder' => 0,
+                        'hidden' => 0
+                    ]);
+                    $ensurePricing((int) Capsule::getPdo()->lastInsertId());
+                }
             }
 
-            $ensurePricing($allocationSubId);
+            multiportal_log('SetupWizard', ['group_id' => $paygGroupId, 'storage_policies' => count($storagePolicyData)], 'Created PAYG Options group');
+        } else {
+            $paygGroupId = (int) $paygGroup->id;
+
+            // Backfill: if PAYG group exists but has no options, add the hidden marker
+            $paygOptionCount = Capsule::table('tblproductconfigoptions')
+                ->where('gid', $paygGroupId)
+                ->count();
+            if ($paygOptionCount === 0) {
+                Capsule::table('tblproductconfigoptions')->insert([
+                    'gid' => $paygGroupId,
+                    'optionname' => 'MP_INIT_FLAG',
+                    'optiontype' => 2, // Radio
+                    'qtyminimum' => 0,
+                    'qtymaximum' => 0,
+                    'order' => 1,
+                    'hidden' => 1
+                ]);
+                $paygMarkerOptionId = Capsule::getPdo()->lastInsertId();
+                Capsule::table('tblproductconfigoptionssub')->insert([
+                    'configid' => $paygMarkerOptionId,
+                    'optionname' => 'Enabled',
+                    'sortorder' => 0,
+                    'hidden' => 0
+                ]);
+                $ensurePricing((int) Capsule::getPdo()->lastInsertId());
+                multiportal_log('SetupWizard', ['group_id' => $paygGroupId], 'Backfilled MP_INIT_FLAG marker option');
+            }
+
+            // Backfill: add storage policies if missing from existing PAYG group
+            $hasStorageOptions = Capsule::table('tblproductconfigoptions')
+                ->where('gid', $paygGroupId)
+                ->where('optionname', 'like', 'Storage - %')
+                ->exists();
+            if (!$hasStorageOptions && !empty($storagePolicyData)) {
+                $paygOrder = Capsule::table('tblproductconfigoptions')
+                    ->where('gid', $paygGroupId)
+                    ->max('order') + 1;
+                foreach ($storagePolicyData as $policy) {
+                    if (!empty($policy['name'])) {
+                        Capsule::table('tblproductconfigoptions')->insert([
+                            'gid' => $paygGroupId,
+                            'optionname' => 'Storage - ' . $policy['name'],
+                            'optiontype' => 4, // Quantity
+                            'qtyminimum' => 0,
+                            'qtymaximum' => 10000,
+                            'order' => $paygOrder++,
+                            'hidden' => 1
+                        ]);
+                        $storageOptionId = Capsule::getPdo()->lastInsertId();
+                        Capsule::table('tblproductconfigoptionssub')->insert([
+                            'configid' => $storageOptionId,
+                            'optionname' => 'GB',
+                            'sortorder' => 0,
+                            'hidden' => 0
+                        ]);
+                        $ensurePricing((int) Capsule::getPdo()->lastInsertId());
+                    }
+                }
+                multiportal_log('SetupWizard', ['group_id' => $paygGroupId, 'storage_policies' => count($storagePolicyData)], 'Backfilled storage policy options');
+            }
+
+            multiportal_log('SetupWizard', ['group_id' => $paygGroupId], 'PAYG Options group already exists');
         }
 
-        // Verify the sub-options were created
-        $createdSubs = Capsule::table('tblproductconfigoptionssub')
-            ->where('configid', $allocationOptionId)
-            ->count();
-        multiportal_log('SetupWizard', ['allocation_subs_count' => $createdSubs], 'Verified Allocation Type sub-options');
+        // =====================================================================
+        // Link the correct group to THIS product based on configoption7
+        // =====================================================================
+        $linkedGroupId = $isPayg ? $paygGroupId : $allocationGroupId;
+        $linkedGroupName = $isPayg ? $paygGroupName : $allocationGroupName;
 
-        // Build success message - keep it simple for WHMCS
-        $message = 'Setup completed successfully! ';
-        $message .= 'Created configurable options group "' . $groupName . '" with ';
-        $message .= 'CPU (1-128), Memory (1-512 GB), ' . count($storagePolicies['data']) . ' storage policies, and Allocation Type. ';
-        $message .= 'IMPORTANT: Due to WHMCS bug, you must now: ';
-        $message .= '1) Go to Configurable Options, ';
-        $message .= '2) Edit "' . $groupName . '", ';
-        $message .= '3) Click any Storage option, ';
-        $message .= '4) Save without changes. ';
-        $message .= 'This fixes the Allocation Type dropdown.';
-        
-        // WHMCS is very limited in what it can display for module commands
-        // We can only return 'success' or 'Error: message'
-        // Any other format shows as an error
-        
-        // The best we can do is return a success message that fits on one line
+        Capsule::table('tblproductconfiglinks')->insert([
+            'gid' => $linkedGroupId,
+            'pid' => $productId
+        ]);
+
+        multiportal_log('SetupWizard', [
+            'product_id' => $productId,
+            'linked_group' => $linkedGroupName,
+            'linked_group_id' => $linkedGroupId,
+            'allocation_group_id' => $allocationGroupId,
+            'payg_group_id' => $paygGroupId,
+            'storage_policies' => count($storagePolicyData)
+        ], 'Setup Wizard completed');
+
         return 'success';
     } catch (Exception $e) {
         multiportal_log('SetupWizard', $params, ['error' => $e->getMessage()]);
+        return 'Error: ' . $e->getMessage();
+    }
+}
+
+/**
+ * Re-Setup Product Options — sync new storage policies from the data center.
+ *
+ * Adds any storage policies that exist in the data center but are missing
+ * from the product's linked configurable option group. Never removes
+ * existing options so admin customizations and client data are preserved.
+ *
+ * @param array $params WHMCS module parameters
+ * @return string 'success' or error message
+ */
+function multiportal_ReSetupProductOptions(array $params)
+{
+    try {
+        $productId = $params['pid'];
+        $dataCenterId = ModuleConfiguration::get($params, ModuleConfiguration::FIELD_DATA_CENTER_ID);
+
+        // Find the linked MultiPortal config group for this product
+        $link = Capsule::table('tblproductconfiglinks')
+            ->join('tblproductconfiggroups', 'tblproductconfiglinks.gid', '=', 'tblproductconfiggroups.id')
+            ->where('tblproductconfiglinks.pid', $productId)
+            ->where('tblproductconfiggroups.name', 'LIKE', '%MultiPortal%')
+            ->first();
+
+        if (!$link) {
+            return 'Error: No MultiPortal config group linked to this product. Run Setup Product Options first.';
+        }
+
+        $groupId = (int) $link->gid;
+        $groupName = $link->name;
+        $isPaygGroup = (stripos($groupName, 'PAYG') !== false);
+
+        // Fetch current storage policies from the data center
+        $api = initiateAPI($params);
+        $vdcMgr = new VDCManager($api);
+        $storagePolicies = $vdcMgr->getStoragePoliciesByDataCenter($dataCenterId);
+        $storagePolicyData = (isset($storagePolicies['data']) && is_array($storagePolicies['data']))
+            ? $storagePolicies['data'] : [];
+
+        if (empty($storagePolicyData)) {
+            return 'No storage policies found in the data center. Nothing to add.';
+        }
+
+        // Get existing storage option names in this group
+        $existingOptions = Capsule::table('tblproductconfigoptions')
+            ->where('gid', $groupId)
+            ->where('optionname', 'like', 'Storage - %')
+            ->pluck('optionname')
+            ->toArray();
+
+        // Pricing helper
+        $currencies = Capsule::table('tblcurrencies')->select('id')->get();
+        $pricingTemplate = [
+            'msetupfee' => '0.00', 'qsetupfee' => '0.00', 'ssetupfee' => '0.00',
+            'asetupfee' => '0.00', 'bsetupfee' => '0.00', 'tsetupfee' => '0.00',
+            'monthly' => '0.00', 'quarterly' => '0.00', 'semiannually' => '0.00',
+            'annually' => '0.00', 'biennially' => '0.00', 'triennially' => '0.00'
+        ];
+        $ensurePricing = function (int $relId) use ($currencies, $pricingTemplate) {
+            foreach ($currencies as $currency) {
+                $existing = Capsule::table('tblpricing')
+                    ->where('type', 'configoptions')
+                    ->where('currency', $currency->id)
+                    ->where('relid', $relId)
+                    ->first();
+                if (!$existing) {
+                    Capsule::table('tblpricing')->insert(array_merge([
+                        'type' => 'configoptions',
+                        'currency' => $currency->id,
+                        'relid' => $relId
+                    ], $pricingTemplate));
+                }
+            }
+        };
+
+        // Add missing storage policies
+        $nextOrder = Capsule::table('tblproductconfigoptions')
+            ->where('gid', $groupId)
+            ->max('order') + 1;
+        $added = 0;
+
+        foreach ($storagePolicyData as $policy) {
+            if (empty($policy['name'])) {
+                continue;
+            }
+            $optionName = 'Storage - ' . $policy['name'];
+            if (in_array($optionName, $existingOptions)) {
+                continue;
+            }
+
+            Capsule::table('tblproductconfigoptions')->insert([
+                'gid' => $groupId,
+                'optionname' => $optionName,
+                'optiontype' => 4, // Quantity
+                'qtyminimum' => 0,
+                'qtymaximum' => 10000,
+                'order' => $nextOrder++,
+                'hidden' => $isPaygGroup ? 1 : 0
+            ]);
+            $storageOptionId = Capsule::getPdo()->lastInsertId();
+            Capsule::table('tblproductconfigoptionssub')->insert([
+                'configid' => $storageOptionId,
+                'optionname' => 'GB',
+                'sortorder' => 0,
+                'hidden' => 0
+            ]);
+            $ensurePricing((int) Capsule::getPdo()->lastInsertId());
+            $added++;
+        }
+
+        multiportal_log('ReSetupProductOptions', [
+            'product_id' => $productId,
+            'group' => $groupName,
+            'existing_storage' => count($existingOptions),
+            'dc_policies' => count($storagePolicyData),
+            'added' => $added
+        ], 'Re-setup completed');
+
+        if ($added === 0) {
+            multiportal_appendAdminNote($params['serviceid'],
+                "Re-Sync Storage Policies: No new policies to add ({$groupName}). "
+                . "Existing: " . count($existingOptions) . ", DC total: " . count($storagePolicyData));
+            return 'success';
+        }
+
+        multiportal_appendAdminNote($params['serviceid'],
+            "Re-Sync Storage Policies: Added {$added} new storage policies to '{$groupName}'. "
+            . "Existing: " . count($existingOptions) . ", DC total: " . count($storagePolicyData));
+
+        return 'success';
+    } catch (Exception $e) {
+        multiportal_log('ReSetupProductOptions', $params, ['error' => $e->getMessage()]);
+        multiportal_appendAdminNote($params['serviceid'],
+            "Re-Sync Storage Policies ERROR: " . $e->getMessage());
+        return 'Error: ' . $e->getMessage();
+    }
+}
+
+/**
+ * Migrate credentials from client-level to service-level custom fields.
+ *
+ * For existing services that predate the per-service credential storage.
+ * Copies Tenant UUID, Username, Password, and URL from client-level fields
+ * into the service's product-level custom fields and tblhosting, then zeroes
+ * out the legacy client-level fields so they don't linger.
+ */
+function multiportal_MigrateCredentials(array $params)
+{
+    try {
+        // Ensure product-level fields exist for this product
+        ensureCustomFieldsExist();
+        $productId = Capsule::table('tblhosting')->where('id', $params['serviceid'])->value('packageid');
+        ensureProductCustomFields($productId);
+
+        $migrated = [];
+        $skipped = [];
+
+        // Migrate Tenant UUID from client-level to service-level custom field
+        $tenantUUID = getClientCustomFieldValue($params, 'MultiPortal Tenant UUID');
+        $existingTenantUUID = getProductCustomFieldValue($params['serviceid'], 'Tenant UUID');
+        if (!empty($tenantUUID)) {
+            if (empty($existingTenantUUID)) {
+                setCustomFieldValue($params['serviceid'], 'Tenant UUID', $tenantUUID);
+                $migrated[] = 'Tenant UUID';
+            } else {
+                $skipped[] = 'Tenant UUID (already has value)';
+            }
+        }
+
+        // Migrate Username/Password from client-level custom fields to tblhosting.
+        // The 'MultiPortal Password' client field has fieldtype=password, so WHMCS
+        // stores the value already encrypted in tblcustomfieldsvalues. We read the
+        // raw DB value and copy it directly into tblhosting.password (which also
+        // expects WHMCS-encrypted format) — no encrypt() call needed.
+        $username = getClientCustomFieldValue($params, 'MultiPortal Username');
+        $passwordField = Capsule::table('tblcustomfields')
+            ->where('type', 'client')
+            ->where('fieldname', 'MultiPortal Password')
+            ->first();
+        $password = null;
+        if ($passwordField) {
+            $password = Capsule::table('tblcustomfieldsvalues')
+                ->where('fieldid', $passwordField->id)
+                ->where('relid', $params['userid'])
+                ->value('value');
+        }
+        if (!empty($username) && !empty($password)) {
+            // Only migrate if tblhosting doesn't already have credentials
+            $hosting = Capsule::table('tblhosting')->where('id', $params['serviceid'])->first();
+            if (empty($hosting->username)) {
+                Capsule::table('tblhosting')
+                    ->where('id', $params['serviceid'])
+                    ->update([
+                        'username' => $username,
+                        'password' => $password
+                    ]);
+                $migrated[] = 'Username/Password (to service record)';
+            } else {
+                $skipped[] = 'Username/Password (already has value)';
+            }
+        }
+
+        // Migrate URL from client-level custom field to service-level
+        $existingURL = getProductCustomFieldValue($params['serviceid'], 'URL');
+        if (empty($existingURL)) {
+            $url = getClientCustomFieldValue($params, 'MultiPortal URL');
+            if (!empty($url)) {
+                setCustomFieldValue($params['serviceid'], 'URL', $url);
+                $migrated[] = 'URL';
+            } else {
+                // Derive URL from server API config if no client-level field exists
+                $apiUrl = ModuleConfiguration::get($params, ModuleConfiguration::FIELD_API_URL);
+                if (!empty($apiUrl)) {
+                    $portalUrl = rtrim($apiUrl, '/');
+                    $portalUrl = preg_replace('#/api(/v\d+)?$#', '', $portalUrl);
+                    setCustomFieldValue($params['serviceid'], 'URL', $portalUrl);
+                    $migrated[] = 'URL (derived from server config)';
+                }
+            }
+        } else {
+            $skipped[] = 'URL (already has value)';
+        }
+
+        // Migrate Last Usage Sync from old relid=0 field to per-product field
+        $oldSyncField = Capsule::table('tblcustomfields')
+            ->where('type', 'product')
+            ->where('fieldname', 'Last Usage Sync')
+            ->where('relid', 0)
+            ->first();
+        $newSyncField = Capsule::table('tblcustomfields')
+            ->where('type', 'product')
+            ->where('fieldname', 'Last Usage Sync')
+            ->where('relid', $productId)
+            ->first();
+        if ($oldSyncField && $newSyncField) {
+            $oldValue = Capsule::table('tblcustomfieldsvalues')
+                ->where('fieldid', $oldSyncField->id)
+                ->where('relid', $params['serviceid'])
+                ->value('value');
+            if (!empty($oldValue)) {
+                // Only copy if the new field is empty
+                $newValue = Capsule::table('tblcustomfieldsvalues')
+                    ->where('fieldid', $newSyncField->id)
+                    ->where('relid', $params['serviceid'])
+                    ->value('value');
+                if (empty($newValue)) {
+                    Capsule::table('tblcustomfieldsvalues')->updateOrInsert(
+                        ['fieldid' => $newSyncField->id, 'relid' => $params['serviceid']],
+                        ['value' => $oldValue]
+                    );
+                    $migrated[] = 'Last Usage Sync';
+                } else {
+                    $skipped[] = 'Last Usage Sync (already has value)';
+                }
+                // Clear old value regardless (legacy field cleanup)
+                Capsule::table('tblcustomfieldsvalues')
+                    ->where('fieldid', $oldSyncField->id)
+                    ->where('relid', $params['serviceid'])
+                    ->update(['value' => '']);
+            }
+        }
+
+        if (empty($migrated) && empty($skipped)) {
+            return 'No legacy data found to migrate.';
+        }
+
+        // Zero out legacy client-level fields now that values are migrated or skipped
+        $legacyFields = ['MultiPortal Tenant UUID', 'MultiPortal Username', 'MultiPortal Password', 'MultiPortal URL'];
+        foreach ($legacyFields as $legacyFieldName) {
+            $legacyField = Capsule::table('tblcustomfields')
+                ->where('type', 'client')
+                ->where('fieldname', $legacyFieldName)
+                ->first();
+            if ($legacyField) {
+                $legacyValue = Capsule::table('tblcustomfieldsvalues')
+                    ->where('fieldid', $legacyField->id)
+                    ->where('relid', $params['userid'])
+                    ->value('value');
+                if (!empty($legacyValue)) {
+                    Capsule::table('tblcustomfieldsvalues')
+                        ->where('fieldid', $legacyField->id)
+                        ->where('relid', $params['userid'])
+                        ->update(['value' => '']);
+                }
+            }
+        }
+        $migrated[] = 'Cleared legacy client-level fields';
+
+        $noteText = "Migrate: " . implode(', ', $migrated);
+        if (!empty($skipped)) {
+            $noteText .= ". Skipped: " . implode(', ', $skipped);
+        }
+
+        multiportal_log('MigrateCredentials', [
+            'service_id' => $params['serviceid'],
+            'migrated' => $migrated,
+            'skipped' => $skipped
+        ], $noteText);
+
+        multiportal_appendAdminNote($params['serviceid'], $noteText);
+
+        return 'success';
+    } catch (Exception $e) {
+        multiportal_appendAdminNote($params['serviceid'],
+            "Migrate Credentials ERROR: " . $e->getMessage());
         return 'Error: ' . $e->getMessage();
     }
 }


### PR DESCRIPTION
Move MultiPortal tenant credentials (Tenant UUID, Username, Password, URL) from client-level custom fields to per-service storage, split configurable options by allocation type, overhaul admin buttons, add auto-migration, and fix 13 bugs.

## Per-Service Credential Storage

Credentials were stored in client-level custom fields — one set per client. A client with VDCs on two MultiPortal servers would have their first credentials overwritten by the second.

Now each service stores its own credentials independently:
- Tenant UUID → product custom field (relid=productId)
- Username/Password → tblhosting.username/password (WHMCS native)
- URL → product custom field (relid=productId)
- Services on the same WHMCS server share credentials via multiportal_findExistingCredentials() sibling lookup
- Read fallback chain: service-level → client-level → null

## Allocation Type Split

Setup Wizard now creates two configurable option groups per DC:
- "MultiPortal Allocation Options - {DC}" — CPU (1-128), Memory (1-512 GB), visible storage policies
- "MultiPortal PAYG Options - {DC}" — hidden MP_INIT_FLAG + hidden storage policies (no CPU/Memory; those default to 1) Group names include DC name for multi-datacenter support. Only the matching group is linked to the product based on configoption7.

## Admin Button Overhaul

All module buttons renamed for clarity, reordered logically:
- Push Config / Pull Config — sync settings with MultiPortal
- Show Current Month's Usage / Show Last Month's Usage
- Bill PayGo Usage — on-demand PAYG billing with duplicate detection
- Re-Sync Storage Policies — pick up new policies from MultiPortal
- Email Credentials — split into two emails for security
- Create / Destroy VDC — with JS confirmation warnings
- MODULE UPGRADE (RUN MIGRATION!) — manual legacy data migration Every action writes a timestamped entry to admin notes.

## Auto-Migration

multiportal_autoMigrateService() runs transparently on every admin service page view (via AdminCustomButtonArray) and nightly via DailyCronJob. Creates per-product custom fields if missing, migrates Tenant UUID, Username/Password, URL, and Last Usage Sync from legacy locations. Writes detailed per-field admin note (success or reason skipped). Clears legacy client-level fields after migration. Never overwrites existing service-level values.

## New Functions (21 total)

Credential management:
- multiportal_getCredential() — fallback chain reader
- multiportal_findExistingCredentials() — sibling service lookup
- multiportal_EmailCredentials() — two-email credential delivery
- multiportal_MigrateCredentials() — manual migration button

PAYG billing:
- multiportal_SyncUsageAndBill() — fetch usage, calculate charges, create billable items with period-hash duplicate detection
- multiportal_calculatePAYGCharges() — InvoiceCreation hook billing
- multiportal_getLastInvoiceDate() — last PAYG invoice lookup
- multiportal_updateInvoiceTotal() — recalculate invoice after adds

Usage display:
- multiportal_fetchUsage() — shared helper for usage buttons
- multiportal_ViewUsage() — current month
- multiportal_ViewLastMonthUsage() — previous month

Configuration:
- multiportal_getAllocationType() — allocation type with fallback
- ensureProductCustomFields() — create per-product fields
- verifyStoragePolicyOptions() — match WHMCS options vs API
- getPaygStoragePoliciesFromDb() — DB fallback for hidden options

Utilities:
- multiportal_log() — structured debug logging
- multiportal_appendAdminNote() — timestamped admin notes (max 50)
- generateSecurePassword() — crypto-secure password generation

Auto-migration:
- multiportal_autoMigrateService() — idempotent legacy migration

Library methods:
- TenantManager::findUserInTenant() — user search with logging
- TenantManager::updateUser() — full-field PUT with merge
- VDCManager::getVDCUsage() — usage metrics for date range
- setCustomFieldValue() — product-level custom field helper
- setClientCustomFieldValue() — client-level custom field helper

## Bugs Fixed

- Tenant user lookup used wrong endpoint (/users → /user)
- updateUser PUT sent only changed fields; API requires ALL fields
- Push Config did not remove storage policies set to 0 GB
- Pull Usage parsed wrong API response structure
- Last Usage Sync used relid=0 (shared); fixed to relid=productId
- MigrateCredentials double-encrypted password on write
- MigrateCredentials read password through helper that returned empty
- CreateAccount allowed duplicate VDCs (no existing VDC check)
- Auto-migration failed silently when target fields didn't exist
- Auto-migration hooked to AdminServiceEdit (fires on save, not view)
- PAYG hidden options not passed through $params['configoptions']
- PAYG CPU/Memory sent as 0; API requires minimum 1
- Email Credentials HTML-encoded the plain text subject line